### PR TITLE
Add cloud spreadsheet abstraction with mock Google Sheets adapter

### DIFF
--- a/src/cloud_adapters/mod.rs
+++ b/src/cloud_adapters/mod.rs
@@ -1,18 +1,105 @@
 //! Adapters for interacting with cloud spreadsheet services.
 
-/// Trait representing a generic spreadsheet that supports appending rows.
-pub trait CloudSpreadsheet {
-    /// Appends a row of data to the spreadsheet.
-    fn append_row(&self, values: &[String]) -> Result<(), String>;
+use std::collections::HashMap;
+
+/// Represents errors that can occur when interacting with a spreadsheet
+/// service.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpreadsheetError {
+    /// The requested sheet does not exist.
+    SheetNotFound,
+    /// The requested row does not exist.
+    RowNotFound,
+    /// Failed to share the sheet with the given recipient.
+    ShareFailed,
+    /// An unspecified error occurred.
+    Unknown,
 }
 
-/// Placeholder adapter for Google Sheets.
-#[derive(Default)]
-pub struct GoogleSheetsAdapter;
+impl std::fmt::Display for SpreadsheetError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SpreadsheetError::SheetNotFound => write!(f, "sheet not found"),
+            SpreadsheetError::RowNotFound => write!(f, "row not found"),
+            SpreadsheetError::ShareFailed => write!(f, "sharing failed"),
+            SpreadsheetError::Unknown => write!(f, "unknown error"),
+        }
+    }
+}
 
-impl CloudSpreadsheet for GoogleSheetsAdapter {
-    fn append_row(&self, _values: &[String]) -> Result<(), String> {
-        // TODO: integrate with the Google Sheets API
-        Ok(())
+impl std::error::Error for SpreadsheetError {}
+
+/// Abstraction over cloud spreadsheet services.
+pub trait CloudSpreadsheetService {
+    /// Creates a new spreadsheet and returns its ID.
+    fn create_sheet(&mut self, title: &str) -> Result<String, SpreadsheetError>;
+    /// Appends a row of data to the given spreadsheet.
+    fn append_row(&mut self, sheet_id: &str, values: Vec<String>) -> Result<(), SpreadsheetError>;
+    /// Reads a specific row from the spreadsheet.
+    fn read_row(&self, sheet_id: &str, index: usize) -> Result<Vec<String>, SpreadsheetError>;
+    /// Lists all rows from the spreadsheet.
+    fn list_rows(&self, sheet_id: &str) -> Result<Vec<Vec<String>>, SpreadsheetError>;
+    /// Shares the spreadsheet with the given email.
+    fn share_sheet(&self, sheet_id: &str, email: &str) -> Result<(), SpreadsheetError>;
+}
+
+/// Mock adapter simulating Google Sheets behaviour.
+#[derive(Default)]
+pub struct GoogleSheetsAdapter {
+    sheets: HashMap<String, Vec<Vec<String>>>,
+    next_id: usize,
+}
+
+impl GoogleSheetsAdapter {
+    /// Creates a new mock adapter instance.
+    pub fn new() -> Self {
+        Self {
+            sheets: HashMap::new(),
+            next_id: 1,
+        }
+    }
+}
+
+impl CloudSpreadsheetService for GoogleSheetsAdapter {
+    fn create_sheet(&mut self, _title: &str) -> Result<String, SpreadsheetError> {
+        let id = format!("sheet{}", self.next_id);
+        self.next_id += 1;
+        self.sheets.insert(id.clone(), Vec::new());
+        Ok(id)
+    }
+
+    fn append_row(&mut self, sheet_id: &str, values: Vec<String>) -> Result<(), SpreadsheetError> {
+        match self.sheets.get_mut(sheet_id) {
+            Some(rows) => {
+                rows.push(values);
+                Ok(())
+            }
+            None => Err(SpreadsheetError::SheetNotFound),
+        }
+    }
+
+    fn read_row(&self, sheet_id: &str, index: usize) -> Result<Vec<String>, SpreadsheetError> {
+        match self.sheets.get(sheet_id) {
+            Some(rows) => rows
+                .get(index)
+                .cloned()
+                .ok_or(SpreadsheetError::RowNotFound),
+            None => Err(SpreadsheetError::SheetNotFound),
+        }
+    }
+
+    fn list_rows(&self, sheet_id: &str) -> Result<Vec<Vec<String>>, SpreadsheetError> {
+        match self.sheets.get(sheet_id) {
+            Some(rows) => Ok(rows.clone()),
+            None => Err(SpreadsheetError::SheetNotFound),
+        }
+    }
+
+    fn share_sheet(&self, sheet_id: &str, _email: &str) -> Result<(), SpreadsheetError> {
+        if self.sheets.contains_key(sheet_id) {
+            Ok(())
+        } else {
+            Err(SpreadsheetError::ShareFailed)
+        }
     }
 }

--- a/tests/cloud_adapter_tests.rs
+++ b/tests/cloud_adapter_tests.rs
@@ -1,0 +1,45 @@
+use rusty_ledger::cloud_adapters::{
+    CloudSpreadsheetService, GoogleSheetsAdapter, SpreadsheetError,
+};
+
+#[test]
+fn create_append_and_list_rows() {
+    let mut adapter = GoogleSheetsAdapter::new();
+    let id = adapter.create_sheet("test").unwrap();
+
+    adapter
+        .append_row(&id, vec!["a".into(), "b".into()])
+        .unwrap();
+    adapter
+        .append_row(&id, vec!["c".into(), "d".into()])
+        .unwrap();
+
+    let rows = adapter.list_rows(&id).unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0], vec!["a", "b"]);
+}
+
+#[test]
+fn reading_nonexistent_sheet_fails() {
+    let adapter = GoogleSheetsAdapter::new();
+    let err = adapter.read_row("missing", 0).unwrap_err();
+    assert_eq!(err, SpreadsheetError::SheetNotFound);
+}
+
+#[test]
+fn reading_nonexistent_row_fails() {
+    let mut adapter = GoogleSheetsAdapter::new();
+    let id = adapter.create_sheet("test").unwrap();
+
+    let err = adapter.read_row(&id, 1).unwrap_err();
+    assert_eq!(err, SpreadsheetError::RowNotFound);
+}
+
+#[test]
+fn sharing_nonexistent_sheet_fails() {
+    let adapter = GoogleSheetsAdapter::new();
+    let err = adapter
+        .share_sheet("missing", "user@example.com")
+        .unwrap_err();
+    assert_eq!(err, SpreadsheetError::ShareFailed);
+}


### PR DESCRIPTION
## Summary
- expand cloud adapter trait into full spreadsheet service abstraction
- implement a mock Google Sheets adapter backed by an in-memory store
- provide comprehensive error enum for spreadsheet operations
- add unit tests covering success and failure scenarios for the adapter

## Testing
- `cargo fmt`
- `cargo test --locked` *(failed: could not access crates.io)*