### PR TITLE
Add retry wrapper for spreadsheet API

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Rust-based library that enables applications to interact with cloud-based spread
 - Cloud Service Integration: Supports integration with services like Google Sheets.
 - User Authentication: Users authenticate via OAuth2 to link their cloud accounts.
 - Data Sharing: Users can share their data with others, controlling access permissions.
+- Resilient API Calls: Automatically retries transient errors with exponential backoff.
 
 # 🚀 Getting Started
 ## Prerequisites

--- a/src/cloud_adapters/retry.rs
+++ b/src/cloud_adapters/retry.rs
@@ -1,0 +1,69 @@
+use std::cell::RefCell;
+use std::thread::sleep;
+use std::time::Duration;
+
+use super::{CloudSpreadsheetService, SpreadsheetError};
+
+/// Wrapper that adds retry logic with exponential backoff to a spreadsheet service.
+///
+/// Transient errors are retried with exponential backoff until `max_retries`
+/// is reached. The delay starts at `base_delay` and doubles after each failed
+/// attempt.
+pub struct RetryingService<S> {
+    inner: RefCell<S>,
+    max_retries: u32,
+    base_delay: Duration,
+}
+
+impl<S> RetryingService<S> {
+    /// Create a new `RetryingService` wrapping `inner`.
+    pub fn new(inner: S, max_retries: u32, base_delay: Duration) -> Self {
+        Self {
+            inner: RefCell::new(inner),
+            max_retries,
+            base_delay,
+        }
+    }
+
+    fn with_retry<T, F>(&self, mut op: F) -> Result<T, SpreadsheetError>
+    where
+        F: FnMut(&mut S) -> Result<T, SpreadsheetError>,
+    {
+        let mut attempt = 0;
+        loop {
+            let result = op(&mut self.inner.borrow_mut());
+            match result {
+                Ok(val) => return Ok(val),
+                Err(e) if e.is_retryable() && attempt < self.max_retries => {
+                    let factor = 2f64.powi(attempt as i32);
+                    let delay = self.base_delay.mul_f64(factor);
+                    sleep(delay);
+                    attempt += 1;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+}
+
+impl<S: CloudSpreadsheetService> CloudSpreadsheetService for RetryingService<S> {
+    fn create_sheet(&mut self, title: &str) -> Result<String, SpreadsheetError> {
+        self.with_retry(|inner| inner.create_sheet(title))
+    }
+
+    fn append_row(&mut self, sheet_id: &str, values: Vec<String>) -> Result<(), SpreadsheetError> {
+        self.with_retry(|inner| inner.append_row(sheet_id, values.clone()))
+    }
+
+    fn read_row(&self, sheet_id: &str, index: usize) -> Result<Vec<String>, SpreadsheetError> {
+        self.with_retry(|inner| inner.read_row(sheet_id, index))
+    }
+
+    fn list_rows(&self, sheet_id: &str) -> Result<Vec<Vec<String>>, SpreadsheetError> {
+        self.with_retry(|inner| inner.list_rows(sheet_id))
+    }
+
+    fn share_sheet(&self, sheet_id: &str, email: &str) -> Result<(), SpreadsheetError> {
+        self.with_retry(|inner| inner.share_sheet(sheet_id, email))
+    }
+}

--- a/tests/retry_tests.rs
+++ b/tests/retry_tests.rs
@@ -1,0 +1,68 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::time::Duration;
+
+use rusty_ledger::cloud_adapters::{CloudSpreadsheetService, RetryingService, SpreadsheetError};
+
+struct FlakyAdapter {
+    fail_times: usize,
+    calls: Rc<RefCell<usize>>,
+}
+
+impl FlakyAdapter {
+    fn new(fail_times: usize, calls: Rc<RefCell<usize>>) -> Self {
+        Self { fail_times, calls }
+    }
+}
+
+impl CloudSpreadsheetService for FlakyAdapter {
+    fn create_sheet(&mut self, _title: &str) -> Result<String, SpreadsheetError> {
+        let mut c = self.calls.borrow_mut();
+        *c += 1;
+        if *c <= self.fail_times {
+            Err(SpreadsheetError::Transient("network".into()))
+        } else {
+            Ok(format!("sheet{c}"))
+        }
+    }
+
+    fn append_row(
+        &mut self,
+        _sheet_id: &str,
+        _values: Vec<String>,
+    ) -> Result<(), SpreadsheetError> {
+        unimplemented!()
+    }
+
+    fn read_row(&self, _sheet_id: &str, _index: usize) -> Result<Vec<String>, SpreadsheetError> {
+        unimplemented!()
+    }
+
+    fn list_rows(&self, _sheet_id: &str) -> Result<Vec<Vec<String>>, SpreadsheetError> {
+        unimplemented!()
+    }
+
+    fn share_sheet(&self, _sheet_id: &str, _email: &str) -> Result<(), SpreadsheetError> {
+        unimplemented!()
+    }
+}
+
+#[test]
+fn retries_and_succeeds() {
+    let calls = Rc::new(RefCell::new(0));
+    let adapter = FlakyAdapter::new(2, Rc::clone(&calls));
+    let mut retry = RetryingService::new(adapter, 3, Duration::from_millis(1));
+    let id = retry.create_sheet("test").unwrap();
+    assert_eq!(id, "sheet3");
+    assert_eq!(*calls.borrow(), 3);
+}
+
+#[test]
+fn gives_up_after_max_retries() {
+    let calls = Rc::new(RefCell::new(0));
+    let adapter = FlakyAdapter::new(5, Rc::clone(&calls));
+    let mut retry = RetryingService::new(adapter, 3, Duration::from_millis(1));
+    let err = retry.create_sheet("test").unwrap_err();
+    assert!(matches!(err, SpreadsheetError::Transient(_)));
+    assert_eq!(*calls.borrow(), 4);
+}


### PR DESCRIPTION
## Summary
- implement `RetryingService` with exponential backoff for transient `SpreadsheetError`s
- extend `SpreadsheetError` with `Transient` and `Permanent` variants
- expose retry wrapper and document error handling behaviour
- test retry logic with a flaky adapter

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings` *(fails: could not download crates)*
- `cargo test` *(fails: could not download crates)*