### PR TITLE
Fix license reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ Comprehensive documentation is available in the docs directory, covering:
 Contributions are welcome! Please read the [CONTRIBUTING](CONTRIBUTING.md) for guidelines on how to contribute to this project
 
 # 📄 License
-This project is licensed under the MIT License - see the [LICENSE](LICENSE.md) file for details.
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary
- fix README license link to `LICENSE`

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_685c6c344544832a964862f331b333c7