### PR TITLE
Update minimum Rust version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Rust-based library that enables applications to interact with cloud-based spread
 
 # 🚀 Getting Started
 ## Prerequisites
-- Rust (version 1.60 or higher)
+- Rust (version 1.74 or higher)
 - Google Cloud account with Sheets API enabled
 - OAuth2 credentials for Google Sheets API
 


### PR DESCRIPTION
## Summary
- document the minimum Rust version compatible with edition 2024

## Testing
- `cargo fmt`
- `cargo clippy`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_685c6ccbdf74832a83f42ed20872bf86