### PR TITLE
Implement row conversion and persistence

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -95,6 +95,24 @@ impl Record {
     pub fn from_json(input: &str) -> Result<Self, serde_json::Error> {
         serde_json::from_str(input)
     }
+
+    /// Converts the record into a row for spreadsheet storage.
+    pub fn to_row(&self) -> Vec<String> {
+        vec![
+            self.id.to_string(),
+            self.timestamp.to_rfc3339(),
+            self.description.clone(),
+            self.debit_account.clone(),
+            self.credit_account.clone(),
+            self.amount.to_string(),
+            self.currency.clone(),
+            self.reference_id
+                .map(|id| id.to_string())
+                .unwrap_or_default(),
+            self.external_reference.clone().unwrap_or_default(),
+            self.tags.join(","),
+        ]
+    }
 }
 
 /// Errors that can occur when interacting with the [`Ledger`].

--- a/src/core/sharing.rs
+++ b/src/core/sharing.rs
@@ -57,6 +57,9 @@ impl<S: CloudSpreadsheetService> SharedLedger<S> {
 
     pub fn commit(&mut self, user: &str, record: Record) -> Result<(), AccessError> {
         self.check(user, Permission::Write)?;
+        self.service
+            .append_row(&self.sheet_id, record.to_row())
+            .map_err(|_| AccessError::ShareFailed)?;
         self.ledger.commit(record);
         Ok(())
     }

--- a/tests/shared_ledger_service_tests.rs
+++ b/tests/shared_ledger_service_tests.rs
@@ -1,0 +1,92 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use rusty_ledger::cloud_adapters::{CloudSpreadsheetService, GoogleSheetsAdapter};
+use rusty_ledger::core::{Record, SharedLedger};
+
+struct CountingAdapter {
+    inner: GoogleSheetsAdapter,
+    append_calls: Rc<RefCell<usize>>,
+}
+
+impl CountingAdapter {
+    fn new(append_calls: Rc<RefCell<usize>>) -> Self {
+        Self {
+            inner: GoogleSheetsAdapter::new(),
+            append_calls,
+        }
+    }
+}
+
+impl CloudSpreadsheetService for CountingAdapter {
+    fn create_sheet(
+        &mut self,
+        title: &str,
+    ) -> Result<String, rusty_ledger::cloud_adapters::SpreadsheetError> {
+        self.inner.create_sheet(title)
+    }
+
+    fn append_row(
+        &mut self,
+        sheet_id: &str,
+        values: Vec<String>,
+    ) -> Result<(), rusty_ledger::cloud_adapters::SpreadsheetError> {
+        *self.append_calls.borrow_mut() += 1;
+        self.inner.append_row(sheet_id, values)
+    }
+
+    fn read_row(
+        &self,
+        sheet_id: &str,
+        index: usize,
+    ) -> Result<Vec<String>, rusty_ledger::cloud_adapters::SpreadsheetError> {
+        self.inner.read_row(sheet_id, index)
+    }
+
+    fn list_rows(
+        &self,
+        sheet_id: &str,
+    ) -> Result<Vec<Vec<String>>, rusty_ledger::cloud_adapters::SpreadsheetError> {
+        self.inner.list_rows(sheet_id)
+    }
+
+    fn share_sheet(
+        &self,
+        sheet_id: &str,
+        email: &str,
+    ) -> Result<(), rusty_ledger::cloud_adapters::SpreadsheetError> {
+        self.inner.share_sheet(sheet_id, email)
+    }
+
+    fn append_rows(
+        &mut self,
+        sheet_id: &str,
+        rows: Vec<Vec<String>>,
+    ) -> Result<(), rusty_ledger::cloud_adapters::SpreadsheetError> {
+        *self.append_calls.borrow_mut() += rows.len();
+        self.inner.append_rows(sheet_id, rows)
+    }
+}
+
+#[test]
+fn commit_invokes_append_row() {
+    let counter = Rc::new(RefCell::new(0));
+    let adapter = CountingAdapter::new(Rc::clone(&counter));
+    let mut ledger = SharedLedger::new(adapter, "owner@example.com").unwrap();
+
+    let record = Record::new(
+        "desc".into(),
+        "cash".into(),
+        "revenue".into(),
+        1.0,
+        "USD".into(),
+        None,
+        None,
+        vec![],
+    )
+    .unwrap();
+
+    ledger.commit("owner@example.com", record).unwrap();
+
+    assert_eq!(*counter.borrow(), 1);
+}


### PR DESCRIPTION
## Summary
- convert `Record` to a spreadsheet row
- persist rows through `SharedLedger::commit`
- test that commit invokes the spreadsheet service

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_685c71c69acc832aa517aa9f6f8e036c