### PR TITLE
Add thread-safe SharedLedger

### DIFF
--- a/src/core/sharing.rs
+++ b/src/core/sharing.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Mutex;
 
 use uuid::Uuid;
 
@@ -20,10 +21,10 @@ pub enum AccessError {
 }
 
 pub struct SharedLedger<S: CloudSpreadsheetService> {
-    ledger: Ledger,
-    service: S,
+    ledger: Mutex<Ledger>,
+    service: Mutex<S>,
     sheet_id: String,
-    permissions: HashMap<String, Permission>,
+    permissions: Mutex<HashMap<String, Permission>>,
 }
 
 impl<S: CloudSpreadsheetService> SharedLedger<S> {
@@ -32,59 +33,70 @@ impl<S: CloudSpreadsheetService> SharedLedger<S> {
         let mut permissions = HashMap::new();
         permissions.insert(owner.to_string(), Permission::Write);
         Ok(Self {
-            ledger: Ledger::default(),
-            service,
+            ledger: Mutex::new(Ledger::default()),
+            service: Mutex::new(service),
             sheet_id,
-            permissions,
+            permissions: Mutex::new(permissions),
         })
     }
 
-    pub fn share_with(&mut self, email: &str, permission: Permission) -> Result<(), AccessError> {
-        self.service
+    pub fn share_with(&self, email: &str, permission: Permission) -> Result<(), AccessError> {
+        let service = self.service.lock().unwrap();
+        service
             .share_sheet(&self.sheet_id, email)
             .map_err(|_| AccessError::ShareFailed)?;
-        self.permissions.insert(email.to_string(), permission);
+        let mut perms = self.permissions.lock().unwrap();
+        perms.insert(email.to_string(), permission);
         Ok(())
     }
 
     fn check(&self, user: &str, required: Permission) -> Result<(), AccessError> {
-        match self.permissions.get(user) {
+        let perms = self.permissions.lock().unwrap();
+        match perms.get(user) {
             Some(Permission::Write) => Ok(()),
             Some(Permission::Read) if required == Permission::Read => Ok(()),
             _ => Err(AccessError::Unauthorized),
         }
     }
 
-    pub fn commit(&mut self, user: &str, record: Record) -> Result<(), AccessError> {
+    pub fn commit(&self, user: &str, record: Record) -> Result<(), AccessError> {
         self.check(user, Permission::Write)?;
-        self.service
-            .append_row(&self.sheet_id, record.to_row())
-            .map_err(|_| AccessError::ShareFailed)?;
-        self.ledger.commit(record);
+        {
+            let mut service = self.service.lock().unwrap();
+            service
+                .append_row(&self.sheet_id, record.to_row())
+                .map_err(|_| AccessError::ShareFailed)?;
+        }
+        self.ledger.lock().unwrap().commit(record);
         Ok(())
     }
 
-    pub fn get_record(&self, user: &str, id: Uuid) -> Result<&Record, AccessError> {
+    pub fn get_record(&self, user: &str, id: Uuid) -> Result<Record, AccessError> {
         self.check(user, Permission::Read)?;
-        self.ledger.get_record(id).map_err(AccessError::Ledger)
+        self.ledger
+            .lock()
+            .unwrap()
+            .get_record(id)
+            .cloned()
+            .map_err(AccessError::Ledger)
     }
 
-    pub fn records<'a>(
-        &'a self,
-        user: &str,
-    ) -> Result<impl Iterator<Item = &'a Record>, AccessError> {
+    pub fn records(&self, user: &str) -> Result<Vec<Record>, AccessError> {
         self.check(user, Permission::Read)?;
-        Ok(self.ledger.records())
+        let ledger = self.ledger.lock().unwrap();
+        Ok(ledger.records().cloned().collect())
     }
 
     pub fn apply_adjustment(
-        &mut self,
+        &self,
         user: &str,
         original_id: Uuid,
         adjustment: Record,
     ) -> Result<(), AccessError> {
         self.check(user, Permission::Write)?;
         self.ledger
+            .lock()
+            .unwrap()
             .apply_adjustment(original_id, adjustment)
             .map_err(AccessError::Ledger)
     }

--- a/tests/access_control_tests.rs
+++ b/tests/access_control_tests.rs
@@ -4,7 +4,7 @@ use rusty_ledger::core::{AccessError, Permission, Record, SharedLedger};
 #[test]
 fn reader_cannot_write() {
     let adapter = GoogleSheetsAdapter::new();
-    let mut ledger = SharedLedger::new(adapter, "owner@example.com").unwrap();
+    let ledger = SharedLedger::new(adapter, "owner@example.com").unwrap();
     ledger
         .share_with("reader@example.com", Permission::Read)
         .unwrap();
@@ -28,7 +28,7 @@ fn reader_cannot_write() {
 #[test]
 fn writer_can_write() {
     let adapter = GoogleSheetsAdapter::new();
-    let mut ledger = SharedLedger::new(adapter, "owner@example.com").unwrap();
+    let ledger = SharedLedger::new(adapter, "owner@example.com").unwrap();
     ledger
         .share_with("writer@example.com", Permission::Write)
         .unwrap();
@@ -47,13 +47,13 @@ fn writer_can_write() {
 
     ledger.commit("writer@example.com", record).unwrap();
 
-    assert_eq!(ledger.records("writer@example.com").unwrap().count(), 1);
+    assert_eq!(ledger.records("writer@example.com").unwrap().len(), 1);
 }
 
 #[test]
 fn access_is_required_for_reads() {
     let adapter = GoogleSheetsAdapter::new();
-    let mut ledger = SharedLedger::new(adapter, "owner@example.com").unwrap();
+    let ledger = SharedLedger::new(adapter, "owner@example.com").unwrap();
 
     let record = Record::new(
         "desc".into(),

--- a/tests/shared_ledger_service_tests.rs
+++ b/tests/shared_ledger_service_tests.rs
@@ -72,7 +72,7 @@ impl CloudSpreadsheetService for CountingAdapter {
 fn commit_invokes_append_row() {
     let counter = Rc::new(RefCell::new(0));
     let adapter = CountingAdapter::new(Rc::clone(&counter));
-    let mut ledger = SharedLedger::new(adapter, "owner@example.com").unwrap();
+    let ledger = SharedLedger::new(adapter, "owner@example.com").unwrap();
 
     let record = Record::new(
         "desc".into(),
@@ -137,7 +137,7 @@ impl CloudSpreadsheetService for FailingShare {
 #[test]
 fn share_with_returns_access_error() {
     let adapter = FailingShare::default();
-    let mut ledger = SharedLedger::new(adapter, "owner@example.com").unwrap();
+    let ledger = SharedLedger::new(adapter, "owner@example.com").unwrap();
     let err = ledger
         .share_with("user@example.com", Permission::Read)
         .unwrap_err();

--- a/tests/thread_safety_tests.rs
+++ b/tests/thread_safety_tests.rs
@@ -1,0 +1,41 @@
+use std::sync::Arc;
+use std::thread;
+
+use rusty_ledger::cloud_adapters::GoogleSheetsAdapter;
+use rusty_ledger::core::{Permission, Record, SharedLedger};
+
+#[test]
+fn concurrent_commits() {
+    let adapter = GoogleSheetsAdapter::new();
+    let ledger = SharedLedger::new(adapter, "owner@example.com").unwrap();
+    ledger
+        .share_with("writer@example.com", Permission::Write)
+        .unwrap();
+
+    let ledger = Arc::new(ledger);
+    let mut handles = Vec::new();
+
+    for _ in 0..10 {
+        let ledger_cloned = Arc::clone(&ledger);
+        handles.push(thread::spawn(move || {
+            let record = Record::new(
+                "desc".into(),
+                "cash".into(),
+                "revenue".into(),
+                1.0,
+                "USD".into(),
+                None,
+                None,
+                vec![],
+            )
+            .unwrap();
+            ledger_cloned.commit("writer@example.com", record).unwrap();
+        }));
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    assert_eq!(ledger.records("writer@example.com").unwrap().len(), 10);
+}


### PR DESCRIPTION
## Summary
- wrap internal `Ledger` with `Mutex`
- adjust `SharedLedger` methods for interior locking
- update tests for new signatures
- add concurrency test

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_685c79e4c6f8832aa4deda2c53ca0ccf