### PR TITLE
Add documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# Documentation
+
+This directory contains detailed documentation for the Rusty Ledger project. The following guides are available:
+
+- [Module Architecture](architecture.md)
+- [Data Model](data_model.md)
+- [Public API Usage](api_usage.md)
+- [Authentication Integration](authentication.md)
+- [Extending Cloud Service Support](extending_cloud_support.md)

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -1,0 +1,23 @@
+# Public API Usage
+
+The easiest way to use the library is to work with the `Ledger` type directly:
+
+```rust
+use rusty_ledger::core::{Ledger, Record};
+
+let mut ledger = Ledger::default();
+let record = Record::new(
+    "example".into(),
+    "cash".into(),
+    "revenue".into(),
+    10.0,
+    "USD".into(),
+    None,
+    None,
+    vec!["sample".into()],
+).unwrap();
+ledger.commit(record);
+```
+
+When integrating with a cloud service, construct an adapter that implements
+`CloudSpreadsheetService` and pass it to `SharedLedger` for multi-user access.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,8 @@
+# Module Architecture
+
+Rusty Ledger is organized into two main modules:
+
+- **core** – Provides the immutable ledger logic and record structures. It defines the `Record`, `Ledger`, and sharing primitives that control access and apply adjustments.
+- **cloud_adapters** – Contains implementations for interacting with remote spreadsheet services. Adapters implement the `CloudSpreadsheetService` trait and can be wrapped with utilities like batching and retry logic.
+
+Each module exposes a minimal surface area so that applications can choose the pieces they need. The `lib.rs` file simply re-exports these modules.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,22 @@
+# Authentication Integration
+
+Authentication is provided through the `AuthManager` type in
+`cloud_adapters::auth`. You supply an `AuthProvider` implementation to perform
+OAuth2 flows and a `TokenStore` for persisting tokens.
+
+```rust,no_run
+use rusty_ledger::cloud_adapters::auth::{AuthManager, MemoryTokenStore, OAuth2Token, AuthProvider};
+
+struct MyProvider;
+impl AuthProvider for MyProvider {
+    fn authorize(&mut self) -> Result<OAuth2Token, AuthError> {
+        unimplemented!()
+    }
+    fn refresh(&mut self, _refresh: &str) -> Result<OAuth2Token, AuthError> {
+        unimplemented!()
+    }
+}
+
+let mut manager = AuthManager::new(MyProvider, MemoryTokenStore::new());
+let token = manager.authenticate("user1")?;
+```

--- a/docs/data_model.md
+++ b/docs/data_model.md
@@ -1,0 +1,14 @@
+# Data Model
+
+A ledger entry is represented by the `Record` struct. Important fields include:
+
+- `id` – Unique identifier generated for each record.
+- `timestamp` – Time of creation in UTC.
+- `description` – Human readable explanation of the transaction.
+- `debit_account` and `credit_account` – The accounts affected by the entry.
+- `amount` and `currency` – Monetary value stored as a positive number.
+- `reference_id` – Optional link to another record when posting an adjustment.
+- `external_reference` – Optional external identifier such as an invoice number.
+- `tags` – Free form strings used for categorisation.
+
+Records are immutable after being committed to the ledger. Adjustments are stored as new records referencing the original entry.

--- a/docs/extending_cloud_support.md
+++ b/docs/extending_cloud_support.md
@@ -1,0 +1,11 @@
+# Extending Cloud Service Support
+
+To add a new spreadsheet backend implement the `CloudSpreadsheetService` trait.
+At minimum you must provide methods for creating a sheet, appending rows,
+reading rows and sharing the sheet with other users.
+
+Once implemented you can optionally wrap the service with utilities such as
+`BatchingCacheService` for caching or `RetryingService` for resiliency.
+
+Adapters are placed under `src/cloud_adapters/` and re-exported in
+`cloud_adapters::mod` so that they can be used by the rest of the crate.

--- a/tests/shared_ledger_service_tests.rs
+++ b/tests/shared_ledger_service_tests.rs
@@ -136,7 +136,7 @@ impl CloudSpreadsheetService for FailingShare {
 
 #[test]
 fn share_with_returns_access_error() {
-    let adapter = FailingShare::default();
+    let adapter = FailingShare;
     let ledger = SharedLedger::new(adapter, "owner@example.com").unwrap();
     let err = ledger
         .share_with("user@example.com", Permission::Read)
@@ -191,7 +191,7 @@ impl CloudSpreadsheetService for FailingCreate {
 
 #[test]
 fn new_propagates_spreadsheet_error() {
-    let adapter = FailingCreate::default();
+    let adapter = FailingCreate;
     let res = SharedLedger::new(adapter, "owner@example.com");
     let err = match res {
         Ok(_) => panic!("expected error"),


### PR DESCRIPTION
## Summary
- add docs folder with architecture, data model, API usage, authentication, and extension guides
- fix unit tests to satisfy Clippy

## Testing
- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_685c82f6f474832ab3182fc841652bcf