### PR TITLE
Add release packages for crate and binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,10 @@ jobs:
         with:
           toolchain: stable
           override: true
-          target: ${{ matrix.target }}
       - name: Install cross
-        run: cargo install cross --locked
+        run: cargo install cross --git https://github.com/cross-rs/cross --locked
       - name: Build
-        run: cross build --release --locked --target ${{ matrix.target }}
+        run: cross build --release --target ${{ matrix.target }}
       - name: Strip
         if: matrix.target != 'x86_64-pc-windows-gnu'
         run: strip target/${{ matrix.target }}/release/rusty-ledger
@@ -33,26 +32,20 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist
-          name=rusty-ledger-${{ github.ref_name }}
+          name=rusty-ledger-${{ github.ref_name }}-${{ matrix.target }}
           bin=target/${{ matrix.target }}/release
           if [[ "${{ matrix.target }}" == 'x86_64-pc-windows-gnu' ]]; then
             cp "$bin/rusty-ledger.exe" "$name.exe"
-            7z a "dist/$name-windows.zip" "$name.exe"
-            sha256sum "dist/$name-windows.zip" > "dist/$name-windows.zip.sha256"
-            echo "archive=dist/$name-windows.zip" >> "$GITHUB_OUTPUT"
-            echo "checksum=dist/$name-windows.zip.sha256" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ matrix.target }}" == 'x86_64-apple-darwin' ]]; then
-            cp "$bin/rusty-ledger" "$name"
-            tar czf "dist/$name-macos.tar.gz" "$name"
-            sha256sum "dist/$name-macos.tar.gz" > "dist/$name-macos.tar.gz.sha256"
-            echo "archive=dist/$name-macos.tar.gz" >> "$GITHUB_OUTPUT"
-            echo "checksum=dist/$name-macos.tar.gz.sha256" >> "$GITHUB_OUTPUT"
+            7z a "dist/$name.zip" "$name.exe"
+            sha256sum "dist/$name.zip" > "dist/$name.zip.sha256"
+            echo "archive=dist/$name.zip" >> "$GITHUB_OUTPUT"
+            echo "checksum=dist/$name.zip.sha256" >> "$GITHUB_OUTPUT"
           else
             cp "$bin/rusty-ledger" "$name"
-            tar czf "dist/$name-linux.tar.gz" "$name"
-            sha256sum "dist/$name-linux.tar.gz" > "dist/$name-linux.tar.gz.sha256"
-            echo "archive=dist/$name-linux.tar.gz" >> "$GITHUB_OUTPUT"
-            echo "checksum=dist/$name-linux.tar.gz.sha256" >> "$GITHUB_OUTPUT"
+            tar czf "dist/$name.tar.gz" "$name"
+            sha256sum "dist/$name.tar.gz" > "dist/$name.tar.gz.sha256"
+            echo "archive=dist/$name.tar.gz" >> "$GITHUB_OUTPUT"
+            echo "checksum=dist/$name.tar.gz.sha256" >> "$GITHUB_OUTPUT"
           fi
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-*'
+
+jobs:
+  build:
+    name: Build Binaries
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Build
+        run: cargo build --release --locked
+      - name: Strip
+        if: matrix.os != 'windows-latest'
+        run: strip target/release/rusty-ledger
+      - name: Package
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          name=rusty-ledger-${{ github.ref_name }}
+          if [[ "${{ matrix.os }}" == 'windows-latest' ]]; then
+            cp target/release/rusty-ledger.exe "$name.exe"
+            7z a "dist/$name-windows.zip" "$name.exe"
+            sha256sum "dist/$name-windows.zip" > "dist/$name-windows.zip.sha256"
+            echo "archive=dist/$name-windows.zip" >> "$GITHUB_OUTPUT"
+            echo "checksum=dist/$name-windows.zip.sha256" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ matrix.os }}" == 'macos-latest' ]]; then
+            cp target/release/rusty-ledger "$name"
+            tar czf "dist/$name-macos.tar.gz" "$name"
+            sha256sum "dist/$name-macos.tar.gz" > "dist/$name-macos.tar.gz.sha256"
+            echo "archive=dist/$name-macos.tar.gz" >> "$GITHUB_OUTPUT"
+            echo "checksum=dist/$name-macos.tar.gz.sha256" >> "$GITHUB_OUTPUT"
+          else
+            cp target/release/rusty-ledger "$name"
+            tar czf "dist/$name-linux.tar.gz" "$name"
+            sha256sum "dist/$name-linux.tar.gz" > "dist/$name-linux.tar.gz.sha256"
+            echo "archive=dist/$name-linux.tar.gz" >> "$GITHUB_OUTPUT"
+            echo "checksum=dist/$name-linux.tar.gz.sha256" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}
+          path: |
+            ${{ steps.package.outputs.archive }}
+            ${{ steps.package.outputs.checksum }}
+
+  crate:
+    name: Package Crate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Build crate package
+        run: cargo package --allow-dirty --no-verify
+      - uses: actions/upload-artifact@v4
+        with:
+          name: crate
+          path: target/package/*.crate
+
+  release:
+    name: Publish Release
+    needs: [build, crate]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: dist/**
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,21 +9,24 @@ on:
 jobs:
   build:
     name: Build Binaries
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+        target: [x86_64-unknown-linux-gnu, x86_64-apple-darwin, x86_64-pc-windows-gnu]
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
+          target: ${{ matrix.target }}
+      - name: Install cross
+        run: cargo install cross --locked
       - name: Build
-        run: cargo build --release --locked
+        run: cross build --release --locked --target ${{ matrix.target }}
       - name: Strip
-        if: matrix.os != 'windows-latest'
-        run: strip target/release/rusty-ledger
+        if: matrix.target != 'x86_64-pc-windows-gnu'
+        run: strip target/${{ matrix.target }}/release/rusty-ledger
       - name: Package
         id: package
         shell: bash
@@ -31,20 +34,21 @@ jobs:
           set -euo pipefail
           mkdir -p dist
           name=rusty-ledger-${{ github.ref_name }}
-          if [[ "${{ matrix.os }}" == 'windows-latest' ]]; then
-            cp target/release/rusty-ledger.exe "$name.exe"
+          bin=target/${{ matrix.target }}/release
+          if [[ "${{ matrix.target }}" == 'x86_64-pc-windows-gnu' ]]; then
+            cp "$bin/rusty-ledger.exe" "$name.exe"
             7z a "dist/$name-windows.zip" "$name.exe"
             sha256sum "dist/$name-windows.zip" > "dist/$name-windows.zip.sha256"
             echo "archive=dist/$name-windows.zip" >> "$GITHUB_OUTPUT"
             echo "checksum=dist/$name-windows.zip.sha256" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ matrix.os }}" == 'macos-latest' ]]; then
-            cp target/release/rusty-ledger "$name"
+          elif [[ "${{ matrix.target }}" == 'x86_64-apple-darwin' ]]; then
+            cp "$bin/rusty-ledger" "$name"
             tar czf "dist/$name-macos.tar.gz" "$name"
             sha256sum "dist/$name-macos.tar.gz" > "dist/$name-macos.tar.gz.sha256"
             echo "archive=dist/$name-macos.tar.gz" >> "$GITHUB_OUTPUT"
             echo "checksum=dist/$name-macos.tar.gz.sha256" >> "$GITHUB_OUTPUT"
           else
-            cp target/release/rusty-ledger "$name"
+            cp "$bin/rusty-ledger" "$name"
             tar czf "dist/$name-linux.tar.gz" "$name"
             sha256sum "dist/$name-linux.tar.gz" > "dist/$name-linux.tar.gz.sha256"
             echo "archive=dist/$name-linux.tar.gz" >> "$GITHUB_OUTPUT"
@@ -52,7 +56,7 @@ jobs:
           fi
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.os }}
+          name: ${{ matrix.target }}
           path: |
             ${{ steps.package.outputs.archive }}
             ${{ steps.package.outputs.checksum }}


### PR DESCRIPTION
## Summary
- trigger releases for tags with optional suffix
- build and package binaries on Linux, macOS, and Windows
- generate a `.crate` package
- publish all artifacts in GitHub Releases with autogenerated notes

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_b_685c8c4e4b98832a8aae0a9f48dfe336