### PR TITLE
Add prerelease support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,3 +93,4 @@ jobs:
         with:
           files: dist/**
           generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,4 @@ This directory contains detailed documentation for the Rusty Ledger project. The
 - [Public API Usage](api_usage.md)
 - [Authentication Integration](authentication.md)
 - [Extending Cloud Service Support](extending_cloud_support.md)
+- [Release Process](release.md)

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,6 @@
+# Release Process
+
+Releases are published automatically when a Git tag is pushed that matches `v*.*.*` or `v*.*.*-*`.
+
+Tags containing a hyphen (e.g. `v1.2.0-beta.1`) are treated as pre-releases. The GitHub workflow sets the
+`prerelease` flag when uploading the release, so these versions appear as pre-releases on GitHub.


### PR DESCRIPTION
## Summary
- release workflow marks prerelease tags using `prerelease` flag
- document release process and link it from docs index

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_685cd474e604832a8140b35643c02ac9