### PR TITLE
Release 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,7 +1173,7 @@ checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "rusty-ledger"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-ledger"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Rust-based library that enables applications to interact with cloud-based spread
 Add the following to your Cargo.toml:
 ```toml
 [dependencies]
-rusty-ledger = "0.1.0"
+rusty-ledger = "1.0.0"
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary
- bump crate version to 1.0.0
- update installation instructions in the README

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_685ce168b178832abf0eecee7ff19195