### PR TITLE
Fix sheet name from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ the CLI.
    # optional: defaults to "Ledger"
    sheet_name = "Custom"
    ```
-4. Save the file. The CLI reads this configuration on startup.
+4. Save the file. The CLI reads this configuration on startup and will use the
+   specified `sheet_name` for all ledger operations.
 
 # 🧪 Running Tests
 ```bash

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use yup_oauth2::{self, InstalledFlowAuthenticator, InstalledFlowReturnMethod};
 struct GoogleSheetsConfig {
     credentials_path: String,
     spreadsheet_id: Option<String>,
+    sheet_name: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Default)]
@@ -148,7 +149,11 @@ async fn adapter_from_config(
         hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
             .build(connector.clone());
     let hub = Sheets::new(client, auth);
-    Ok(GoogleSheets4Adapter::new(hub))
+    let adapter = match &cfg.sheet_name {
+        Some(name) => GoogleSheets4Adapter::with_sheet_name(hub, name.clone()),
+        None => GoogleSheets4Adapter::new(hub),
+    };
+    Ok(adapter)
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/tests/config_parse_tests.rs
+++ b/tests/config_parse_tests.rs
@@ -1,0 +1,25 @@
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct GoogleSheetsConfig {
+    credentials_path: String,
+    spreadsheet_id: Option<String>,
+    sheet_name: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct Config {
+    google_sheets: GoogleSheetsConfig,
+}
+
+#[test]
+fn parses_sheet_name() {
+    let toml = r#"
+[google_sheets]
+credentials_path = "cred.json"
+spreadsheet_id = "abc"
+sheet_name = "Custom"
+"#;
+    let cfg: Config = toml::from_str(toml).unwrap();
+    assert_eq!(cfg.google_sheets.sheet_name.as_deref(), Some("Custom"));
+}


### PR DESCRIPTION
## Summary
- add `sheet_name` option to configuration
- pass `sheet_name` when constructing GoogleSheets4Adapter
- clarify in README that the CLI uses `sheet_name`
- test parsing of `sheet_name`

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_685ced0014b4832abaf2734ceee2c4db