### PR TITLE
Update public API docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ This directory contains detailed documentation for the Rusty Ledger project. The
 
 - [Module Architecture](architecture.md)
 - [Data Model](data_model.md)
-- [Public API Usage](api_usage.md)
+- [Public API Reference](api_usage.md)
 - [Authentication Integration](authentication.md)
 - [Extending Cloud Service Support](extending_cloud_support.md)
 - [Release Process](release.md)

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -1,4 +1,4 @@
-# Public API Usage
+# Public API Reference
 
 The easiest way to use the library is to work with the `Ledger` type directly:
 
@@ -19,5 +19,81 @@ let record = Record::new(
 ledger.commit(record);
 ```
 
+## Ledger Operation Examples
+
+### Reading a record
+
+```rust
+let retrieved = ledger.get_record(record.id).unwrap();
+println!("{} -> {}", retrieved.debit_account, retrieved.credit_account);
+```
+
+### Listing records
+
+```rust
+for entry in ledger.records() {
+    println!("{}: {}", entry.id, entry.description);
+}
+```
+
+### Applying an adjustment
+
+```rust
+let adj = Record::new(
+    "refund".into(),
+    "revenue".into(),
+    "cash".into(),
+    10.0,
+    "USD".into(),
+    None,
+    None,
+    vec![],
+).unwrap();
+ledger.apply_adjustment(record.id, adj).unwrap();
+
+for item in ledger.adjustment_history(record.id) {
+    println!("adjustment {}", item.id);
+}
+```
+
 When integrating with a cloud service, construct an adapter that implements
 `CloudSpreadsheetService` and pass it to `SharedLedger` for multi-user access.
+
+```rust
+use rusty_ledger::cloud_adapters::GoogleSheetsAdapter;
+use rusty_ledger::core::{Permission, SharedLedger};
+
+let adapter = GoogleSheetsAdapter::new();
+let ledger = SharedLedger::new(adapter, "owner@example.com").unwrap();
+ledger.commit("owner@example.com", record.clone()).unwrap();
+let all = ledger.records("owner@example.com").unwrap();
+ledger.share_with("reader@example.com", Permission::Read).unwrap();
+```
+
+## API Overview
+
+### Core
+
+- `Record` – immutable ledger entry structure.
+- `RecordError` – validation errors returned by `Record::new`.
+- `Ledger` – in-memory append-only store for `Record`s.
+- `LedgerError` – failures that can occur when using `Ledger`.
+- `SharedLedger` – multi-user wrapper around a `Ledger` backed by a spreadsheet service.
+- `Permission` – access levels for `SharedLedger` operations.
+- `AccessError` – errors produced by `SharedLedger` methods.
+
+### Cloud Adapters
+
+- `CloudSpreadsheetService` – trait abstracting spreadsheet backends.
+- `SpreadsheetError` – common error type returned by services.
+- `GoogleSheetsAdapter` – in-memory adapter useful for tests.
+- `GoogleSheets4Adapter` – adapter using the real Google Sheets API.
+- `BatchingCacheService` – wrapper that batches writes and caches reads.
+- `EvictionPolicy` – strategy used by `BatchingCacheService` when caching.
+- `RetryingService` – wrapper adding retry logic with exponential backoff.
+- `AuthManager` – manages OAuth tokens using an `AuthProvider` and `TokenStore`.
+- `AuthProvider` and `TokenStore` – traits for pluggable authentication.
+- `MemoryTokenStore` and `FileTokenStore` – built-in `TokenStore` implementations.
+- `OAuth2Token` and `AuthError` – types describing authentication tokens and failures.
+- `initial_oauth_login` – helper function to perform the installed OAuth flow.
+- `HyperClient` and `HyperConnector` – client types re-exported for Google Sheets integrations.


### PR DESCRIPTION
## Summary
- document all public APIs in `api_usage.md`
- adjust docs index to reference the new API overview
- add examples for all ledger operations

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_685d930d0e9c832a96efd7bbc945d5b1