### PR TITLE
Add statement importers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,6 +1048,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "qif"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e61f755606130439830f7dbc00d366dae6c511659c5b436d22e75e1cc46c52"
+dependencies = [
+ "chrono",
+ "regex",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,7 +1218,10 @@ version = "1.0.0"
 dependencies = [
  "chrono",
  "clap",
+ "csv",
  "google-sheets4",
+ "qif",
+ "quick-xml",
  "serde",
  "serde_json",
  "tokio",
@@ -1546,6 +1590,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 clap = { version = "4", features = ["derive"] }
 toml = "0.7"
 yup-oauth2 = "11"
+csv = "1"
+qif = "0.1"
+quick-xml = "0.37"
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/src/import/csv.rs
+++ b/src/import/csv.rs
@@ -1,0 +1,50 @@
+use std::path::Path;
+
+use csv::Reader;
+use serde::Deserialize;
+
+use super::{ImportError, StatementImporter};
+use crate::core::Record;
+
+#[derive(Deserialize)]
+struct CsvRow {
+    description: String,
+    debit_account: String,
+    credit_account: String,
+    amount: f64,
+    currency: String,
+}
+
+pub struct CsvImporter;
+
+impl CsvImporter {
+    fn parse_internal(path: &Path) -> Result<Vec<Record>, ImportError> {
+        let mut rdr = Reader::from_path(path).map_err(|e| ImportError::Parse(e.to_string()))?;
+        let mut records = Vec::new();
+        for result in rdr.deserialize() {
+            let row: CsvRow = result.map_err(|e| ImportError::Parse(e.to_string()))?;
+            let rec = Record::new(
+                row.description,
+                row.debit_account,
+                row.credit_account,
+                row.amount,
+                row.currency,
+                None,
+                None,
+                vec![],
+            )?;
+            records.push(rec);
+        }
+        Ok(records)
+    }
+}
+
+impl StatementImporter for CsvImporter {
+    fn parse(path: &Path) -> Result<Vec<Record>, ImportError> {
+        Self::parse_internal(path)
+    }
+}
+
+pub fn parse(path: &Path) -> Result<Vec<Record>, ImportError> {
+    CsvImporter::parse(path)
+}

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -1,0 +1,50 @@
+use std::path::Path;
+
+use crate::core::{Record, RecordError};
+
+#[derive(Debug)]
+pub enum ImportError {
+    Io(std::io::Error),
+    Parse(String),
+    Record(RecordError),
+}
+
+impl std::fmt::Display for ImportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ImportError::Io(e) => write!(f, "io error: {e}"),
+            ImportError::Parse(e) => write!(f, "parse error: {e}"),
+            ImportError::Record(e) => write!(f, "record error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ImportError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ImportError::Io(e) => Some(e),
+            ImportError::Record(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for ImportError {
+    fn from(e: std::io::Error) -> Self {
+        ImportError::Io(e)
+    }
+}
+
+impl From<RecordError> for ImportError {
+    fn from(e: RecordError) -> Self {
+        ImportError::Record(e)
+    }
+}
+
+pub trait StatementImporter {
+    fn parse(path: &Path) -> Result<Vec<Record>, ImportError>;
+}
+
+pub mod csv;
+pub mod ofx;
+pub mod qif;

--- a/src/import/ofx.rs
+++ b/src/import/ofx.rs
@@ -1,0 +1,94 @@
+use std::path::Path;
+
+use quick_xml::Reader;
+use quick_xml::events::Event;
+
+use super::{ImportError, StatementImporter};
+use crate::core::Record;
+
+pub struct OfxImporter;
+
+impl OfxImporter {
+    fn parse_internal(path: &Path) -> Result<Vec<Record>, ImportError> {
+        let content = std::fs::read_to_string(path)?;
+        let mut reader = Reader::from_str(&content);
+        reader.config_mut().trim_text(true);
+        let mut buf = Vec::new();
+        let mut records = Vec::new();
+        let mut in_stmt = false;
+        let mut current_tag = String::new();
+        let mut amount: Option<f64> = None;
+        let mut name: Option<String> = None;
+
+        loop {
+            match reader.read_event_into(&mut buf) {
+                Ok(Event::Start(e)) => {
+                    let tag = String::from_utf8_lossy(e.name().as_ref()).to_uppercase();
+                    if tag == "STMTTRN" {
+                        in_stmt = true;
+                        amount = None;
+                        name = None;
+                    } else if in_stmt {
+                        current_tag = tag;
+                    }
+                }
+                Ok(Event::End(e)) => {
+                    let tag = String::from_utf8_lossy(e.name().as_ref()).to_uppercase();
+                    if tag == "STMTTRN" {
+                        if let (Some(a), Some(n)) = (amount, name.clone()) {
+                            let (debit, credit) = if a < 0.0 {
+                                ("expenses".to_string(), "bank".to_string())
+                            } else {
+                                ("bank".to_string(), "income".to_string())
+                            };
+                            let rec = Record::new(
+                                n,
+                                debit,
+                                credit,
+                                a.abs(),
+                                "USD".into(),
+                                None,
+                                None,
+                                vec![],
+                            )?;
+                            records.push(rec);
+                        }
+                        in_stmt = false;
+                    } else {
+                        current_tag.clear();
+                    }
+                }
+                Ok(Event::Text(t)) => {
+                    if in_stmt {
+                        match current_tag.as_str() {
+                            "TRNAMT" => {
+                                if let Ok(v) = t.unescape().unwrap_or_default().parse::<f64>() {
+                                    amount = Some(v);
+                                }
+                            }
+                            "NAME" => {
+                                name = Some(t.unescape().unwrap_or_default().to_string());
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                Ok(Event::Eof) => break,
+                Err(e) => return Err(ImportError::Parse(e.to_string())),
+                _ => {}
+            }
+            buf.clear();
+        }
+        Ok(records)
+    }
+}
+
+impl StatementImporter for OfxImporter {
+    fn parse(path: &Path) -> Result<Vec<Record>, ImportError> {
+        Self::parse_internal(path)
+    }
+}
+
+pub fn parse(path: &Path) -> Result<Vec<Record>, ImportError> {
+    OfxImporter::parse(path)
+}

--- a/src/import/qif.rs
+++ b/src/import/qif.rs
@@ -1,0 +1,60 @@
+use std::path::Path;
+
+use qif::{DateFormat, QIF};
+
+use super::{ImportError, StatementImporter};
+use crate::core::Record;
+
+pub struct QifImporter;
+
+impl QifImporter {
+    fn parse_internal(path: &Path) -> Result<Vec<Record>, ImportError> {
+        let content = std::fs::read_to_string(path)?;
+        let qif = QIF::from_str(&content, &DateFormat::MonthDayFullYear);
+        let mut records = Vec::new();
+        let sections = [
+            qif.cash.as_ref(),
+            qif.bank.as_ref(),
+            qif.credit_card.as_ref(),
+            qif.liability.as_ref(),
+            qif.asset.as_ref(),
+        ];
+        for sec in sections.into_iter().flatten() {
+            for tx in &sec.transactions {
+                let desc = if !tx.memo.is_empty() {
+                    tx.memo.clone()
+                } else {
+                    tx.vendor.clone()
+                };
+                let amt = tx.amount;
+                let (debit, credit) = if amt < 0.0 {
+                    ("expenses".to_string(), "bank".to_string())
+                } else {
+                    ("bank".to_string(), "income".to_string())
+                };
+                let rec = Record::new(
+                    desc,
+                    debit,
+                    credit,
+                    amt.abs(),
+                    "USD".into(),
+                    None,
+                    None,
+                    vec![],
+                )?;
+                records.push(rec);
+            }
+        }
+        Ok(records)
+    }
+}
+
+impl StatementImporter for QifImporter {
+    fn parse(path: &Path) -> Result<Vec<Record>, ImportError> {
+        Self::parse_internal(path)
+    }
+}
+
+pub fn parse(path: &Path) -> Result<Vec<Record>, ImportError> {
+    QifImporter::parse(path)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@
 
 pub mod cloud_adapters;
 pub mod core;
+pub mod import;

--- a/tests/import_tests.rs
+++ b/tests/import_tests.rs
@@ -1,6 +1,5 @@
 use rusty_ledger::import::{csv, ofx, qif};
 use std::fs::write;
-use std::path::Path;
 
 fn write_temp(name: &str, content: &str) -> std::path::PathBuf {
     let path = std::env::temp_dir().join(name);

--- a/tests/import_tests.rs
+++ b/tests/import_tests.rs
@@ -1,0 +1,47 @@
+use rusty_ledger::import::{csv, ofx, qif};
+use std::fs::write;
+use std::path::Path;
+
+fn write_temp(name: &str, content: &str) -> std::path::PathBuf {
+    let path = std::env::temp_dir().join(name);
+    write(&path, content).unwrap();
+    path
+}
+
+#[test]
+fn csv_parsing() {
+    let data = "description,debit_account,credit_account,amount,currency\nCoffee,expenses:food,cash,3.50,USD\n";
+    let path = write_temp("test.csv", data);
+    let records = csv::parse(&path).unwrap();
+    assert_eq!(records.len(), 1);
+    let r = &records[0];
+    assert_eq!(r.description, "Coffee");
+    assert_eq!(r.debit_account, "expenses:food");
+    assert_eq!(r.credit_account, "cash");
+    assert_eq!(r.amount, 3.50);
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn qif_parsing() {
+    let qif_content = "!Type:Bank\nD01/01/2024\nT-10.00\nPCoffee\nM\n^\n";
+    let path = write_temp("test.qif", qif_content);
+    let records = qif::parse(&path).unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].description, "Coffee");
+    assert_eq!(records[0].amount, 10.0);
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn ofx_parsing() {
+    let ofx_content = r#"<OFX><BANKMSGSRSV1><STMTTRNRS><STMTRS><BANKTRANLIST>
+<STMTTRN><TRNAMT>-7.00</TRNAMT><NAME>Snack</NAME></STMTTRN>
+</BANKTRANLIST></STMTRS></STMTTRNRS></BANKMSGSRSV1></OFX>"#;
+    let path = write_temp("test.ofx", ofx_content);
+    let records = ofx::parse(&path).unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].description, "Snack");
+    assert_eq!(records[0].amount, 7.0);
+    let _ = std::fs::remove_file(path);
+}


### PR DESCRIPTION
## Summary
- add `import` module with `StatementImporter` trait
- implement CSV, QIF, and OFX parsers
- add dependencies for CSV/QIF/OFX parsing
- add unit tests for statement importers

## Testing
- `cargo fmt`
- `cargo clippy --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_b_685d9fa4f368832a8610828e48326e0d