### PR TITLE
Document CLI import feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ Switch to a different sheet by URL:
 $ cargo run --bin ledger -- switch --link "https://docs.google.com/spreadsheets/d/<ID>/edit"
 ```
 
+Import statements from existing files. Supported formats are **csv**, **qif**, and **ofx**:
+
+```bash
+$ cargo run --bin ledger -- import --format csv --file transactions.csv
+```
+
 # 🛠️ Configuration
 Rusty Ledger looks for a `config.toml` file in the same directory as the
 binary. This file stores your OAuth credentials and the spreadsheet ID used by

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -70,6 +70,18 @@ let all = ledger.records("owner@example.com").unwrap();
 ledger.share_with("reader@example.com", Permission::Read).unwrap();
 ```
 
+### Importing statements
+
+Use the parsers in the `import` module to convert existing statements into `Record`s.
+Each parser returns a vector of records ready for insertion:
+
+```rust
+use rusty_ledger::import::{csv, ofx, qif};
+use std::path::Path;
+
+let records = csv::parse(Path::new("transactions.csv"))?;
+```
+
 ## API Overview
 
 ### Core


### PR DESCRIPTION
## Summary
- explain how to import statements via the CLI
- mention supported formats and example usage
- show how to call the parsers from code

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_685da6418e20832abe7db4a691eafbc4