### PR TITLE
Add CSV column mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Import statements from existing files. Supported formats are **csv**, **qif**, a
 ```bash
 $ cargo run --bin ledger -- import --format csv --file transactions.csv
 ```
+To map custom column headers, construct a `CsvMapping` and call
+`csv::parse_with_mapping` in your code.
 
 # 🛠️ Configuration
 Rusty Ledger looks for a `config.toml` file in the same directory as the

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -80,6 +80,16 @@ use rusty_ledger::import::{csv, ofx, qif};
 use std::path::Path;
 
 let records = csv::parse(Path::new("transactions.csv"))?;
+
+// provide custom column names when the CSV headers differ
+let mapping = csv::CsvMapping {
+    description: "desc".into(),
+    debit_account: "debit".into(),
+    credit_account: "credit".into(),
+    amount: "value".into(),
+    currency: "curr".into(),
+};
+let custom = csv::parse_with_mapping(Path::new("other.csv"), &mapping)?;
 ```
 
 ## API Overview

--- a/src/import/csv.rs
+++ b/src/import/csv.rs
@@ -1,34 +1,67 @@
 use std::path::Path;
 
-use csv::Reader;
-use serde::Deserialize;
+use csv::{Reader, StringRecord};
 
 use super::{ImportError, StatementImporter};
 use crate::core::Record;
 
-#[derive(Deserialize)]
-struct CsvRow {
-    description: String,
-    debit_account: String,
-    credit_account: String,
-    amount: f64,
-    currency: String,
+/// Mapping of CSV column names to [`Record`] fields.
+#[derive(Debug, Clone)]
+pub struct CsvMapping {
+    pub description: String,
+    pub debit_account: String,
+    pub credit_account: String,
+    pub amount: String,
+    pub currency: String,
+}
+
+impl Default for CsvMapping {
+    fn default() -> Self {
+        Self {
+            description: "description".into(),
+            debit_account: "debit_account".into(),
+            credit_account: "credit_account".into(),
+            amount: "amount".into(),
+            currency: "currency".into(),
+        }
+    }
 }
 
 pub struct CsvImporter;
 
 impl CsvImporter {
-    fn parse_internal(path: &Path) -> Result<Vec<Record>, ImportError> {
+    fn parse_internal(path: &Path, mapping: &CsvMapping) -> Result<Vec<Record>, ImportError> {
         let mut rdr = Reader::from_path(path).map_err(|e| ImportError::Parse(e.to_string()))?;
+        let headers = rdr
+            .headers()
+            .map_err(|e| ImportError::Parse(e.to_string()))?
+            .clone();
+        let idx = |name: &str| {
+            headers
+                .iter()
+                .position(|h| h == name)
+                .ok_or_else(|| ImportError::Parse(format!("missing column {name}")))
+        };
+        let desc_idx = idx(&mapping.description)?;
+        let debit_idx = idx(&mapping.debit_account)?;
+        let credit_idx = idx(&mapping.credit_account)?;
+        let amount_idx = idx(&mapping.amount)?;
+        let currency_idx = idx(&mapping.currency)?;
+
         let mut records = Vec::new();
-        for result in rdr.deserialize() {
-            let row: CsvRow = result.map_err(|e| ImportError::Parse(e.to_string()))?;
+        for result in rdr.records() {
+            let row: StringRecord = result.map_err(|e| ImportError::Parse(e.to_string()))?;
+            let amount_val: f64 = row
+                .get(amount_idx)
+                .ok_or_else(|| ImportError::Parse("missing amount".into()))?
+                .parse::<f64>()
+                .map_err(|e: std::num::ParseFloatError| ImportError::Parse(e.to_string()))?;
             let rec = Record::new(
-                row.description,
-                row.debit_account,
-                row.credit_account,
-                row.amount,
-                row.currency,
+                row.get(desc_idx).unwrap_or_default().to_string(),
+                row.get(debit_idx).unwrap_or_default().to_string(),
+                row.get(credit_idx).unwrap_or_default().to_string(),
+                amount_val,
+                row.get(currency_idx).unwrap_or_default().to_string(),
                 None,
                 None,
                 vec![],
@@ -37,14 +70,27 @@ impl CsvImporter {
         }
         Ok(records)
     }
+
+    /// Parses a CSV file using the provided column mapping.
+    pub fn parse_with_mapping(
+        path: &Path,
+        mapping: &CsvMapping,
+    ) -> Result<Vec<Record>, ImportError> {
+        Self::parse_internal(path, mapping)
+    }
 }
 
 impl StatementImporter for CsvImporter {
     fn parse(path: &Path) -> Result<Vec<Record>, ImportError> {
-        Self::parse_internal(path)
+        Self::parse_internal(path, &CsvMapping::default())
     }
 }
 
 pub fn parse(path: &Path) -> Result<Vec<Record>, ImportError> {
     CsvImporter::parse(path)
+}
+
+/// Convenience wrapper around [`CsvImporter::parse_with_mapping`].
+pub fn parse_with_mapping(path: &Path, mapping: &CsvMapping) -> Result<Vec<Record>, ImportError> {
+    CsvImporter::parse_with_mapping(path, mapping)
 }

--- a/tests/import_tests.rs
+++ b/tests/import_tests.rs
@@ -44,3 +44,24 @@ fn ofx_parsing() {
     assert_eq!(records[0].amount, 7.0);
     let _ = std::fs::remove_file(path);
 }
+
+#[test]
+fn csv_parsing_with_mapping() {
+    let data = "desc,credit,debit,value,curr\nCoffee,cash,expenses:food,4.20,USD\n";
+    let path = write_temp("test_map.csv", data);
+    let mapping = csv::CsvMapping {
+        description: "desc".into(),
+        debit_account: "debit".into(),
+        credit_account: "credit".into(),
+        amount: "value".into(),
+        currency: "curr".into(),
+    };
+    let records = csv::parse_with_mapping(&path, &mapping).unwrap();
+    assert_eq!(records.len(), 1);
+    let r = &records[0];
+    assert_eq!(r.description, "Coffee");
+    assert_eq!(r.debit_account, "expenses:food");
+    assert_eq!(r.credit_account, "cash");
+    assert_eq!(r.amount, 4.20);
+    let _ = std::fs::remove_file(path);
+}


### PR DESCRIPTION
## Summary
- allow CSV importer to accept custom column mappings
- add docs for how to map headers
- test parsing using custom mappings

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_685da97c21f8832ab95d8344305327d2