### PR TITLE
Add CSV mapping options to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,11 @@ $ cargo run --bin ledger -- switch --link "https://docs.google.com/spreadsheets/
 Import statements from existing files. Supported formats are **csv**, **qif**, and **ofx**:
 
 ```bash
-$ cargo run --bin ledger -- import --format csv --file transactions.csv
+$ cargo run --bin ledger -- import --format csv --file transactions.csv \
+    --map-description desc --map-debit debit --map-credit credit \
+    --map-amount value --map-currency curr
 ```
-To map custom column headers, construct a `CsvMapping` and call
-`csv::parse_with_mapping` in your code.
+Mapping flags override the default column names when importing CSV files.
 
 # 🛠️ Configuration
 Rusty Ledger looks for a `config.toml` file in the same directory as the


### PR DESCRIPTION
## Summary
- update `ledger` CLI to accept column mapping flags when importing CSV files
- describe new CLI flags in README
- test `CsvMapArgs` for mapping conversions

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_685dac3c23dc832abc093008629feb64