### PR TITLE
Clarify use of official API

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ fn main() {
 }
 ```
 
-To work with a live Google Sheet, construct a `GoogleSheets4Adapter` using the
-`google-sheets4` crate. You may optionally specify the worksheet name when
-creating the adapter; otherwise, it defaults to `Ledger`:
+To work with a live Google Sheet, construct a `GoogleSheets4Adapter` that
+communicates with the official Google Sheets REST API. This approach avoids
+extra third‑party wrappers and keeps the dependency surface minimal. You may
+optionally specify the worksheet name when creating the adapter; otherwise, it
+defaults to `Ledger`:
 
 ```rust,no_run
 use rusty_ledger::cloud_adapters::{GoogleSheets4Adapter, HyperConnector};

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -13,7 +13,7 @@ This project provides a unified interface for applications to interact with clou
 # 3. Technical Stack
 
 - Programming Language: Rust, for its performance and safety.
-- API Integration: Utilize the google-sheets4 Rust crate for Google Sheets API interactions.
+- API Integration: Call the official Google Sheets REST API directly over HTTP, using `hyper` for the client implementation.
 - Authentication: Implement OAuth2 for secure user authentication and authorization.
 - Data Storage Format: Each record includes metadata such as timestamps and unique identifiers to maintain immutability.
 


### PR DESCRIPTION
## Summary
- note that the Google Sheets adapter communicates with the official REST API
- describe calling the Sheets API directly in the design spec

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_685db6b3ed0c832a8aaec3b11e4fc66c