### PR TITLE
Remove google-sheets4 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
@@ -142,8 +142,14 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -153,15 +159,21 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
@@ -171,18 +183,18 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.24"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chrono"
@@ -247,6 +259,16 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -280,41 +302,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -357,16 +344,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.19"
+name = "encoding_rs"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -375,10 +359,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -508,46 +523,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "google-apis-common"
-version = "7.0.0"
+name = "h2"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7530ee92a7e9247c3294ae1b84ea98474dbc27563c49a14d3938e816499bf38f"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
- "base64",
- "chrono",
- "http",
- "http-body-util",
- "hyper",
- "hyper-util",
- "itertools",
- "mime",
- "percent-encoding",
- "serde",
- "serde_json",
- "serde_with",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
  "tokio",
- "url",
- "yup-oauth2",
-]
-
-[[package]]
-name = "google-sheets4"
-version = "6.0.0+20240621"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f8ccfc6418e81d1e2ed66fad49d0487526281505b8a0ed8ee770dc7d6bb1e5"
-dependencies = [
- "chrono",
- "google-apis-common",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "mime",
- "serde",
- "serde_json",
- "serde_with",
- "tokio",
- "url",
- "yup-oauth2",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -561,19 +552,13 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
- "indexmap 2.9.0",
+ "http 1.3.1",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -594,10 +579,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "hex"
-version = "0.4.3"
+name = "http"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
 
 [[package]]
 name = "http"
@@ -612,12 +602,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -628,8 +629,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -647,6 +648,30 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
@@ -654,9 +679,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.10",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -668,19 +693,46 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.3.1",
+ "hyper 1.6.0",
  "hyper-util",
- "rustls",
+ "rustls 0.23.28",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.2",
  "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -693,9 +745,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.6.0",
  "libc",
  "pin-project-lite",
  "socket2",
@@ -815,12 +867,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,40 +889,25 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.9.0"
+name = "ipnet"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
-dependencies = [
- "equivalent",
- "hashbrown 0.15.4",
- "serde",
-]
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itoa"
@@ -896,9 +927,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -914,9 +951,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "mime"
@@ -942,6 +979,23 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 2.11.1",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1000,10 +1054,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1022,6 +1114,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potential_utf"
@@ -1078,29 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
-
-[[package]]
-name = "ref-cast"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "regex"
@@ -1132,6 +1210,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-rustls 0.24.2",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-rustls 0.24.1",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,6 +1274,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1160,7 +1307,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.3",
  "subtle",
  "zeroize",
 ]
@@ -1174,7 +1321,16 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.2.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -1193,6 +1349,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1219,9 +1385,9 @@ dependencies = [
  "chrono",
  "clap",
  "csv",
- "google-sheets4",
  "qif",
  "quick-xml",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -1247,15 +1413,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "schemars"
-version = "0.9.0"
+name = "sct"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1266,12 +1430,25 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.9.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags",
- "core-foundation",
+ "bitflags 2.9.1",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1329,34 +1506,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "3.13.0"
+name = "serde_urlencoded"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
- "base64",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.9.0",
- "schemars",
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
- "serde_derive",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1407,14 +1565,20 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"
@@ -1428,13 +1592,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "time"
 version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -1498,12 +1695,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls",
+ "rustls 0.23.28",
  "tokio",
 ]
 
@@ -1547,7 +1764,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1646,6 +1863,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1696,6 +1919,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1726,6 +1962,22 @@ checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "windows-core"
@@ -1764,9 +2016,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"
@@ -1788,11 +2040,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1801,7 +2062,31 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1810,15 +2095,37 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1827,10 +2134,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1839,10 +2170,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1851,10 +2200,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1863,10 +2236,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -1878,6 +2269,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "wiremock"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1885,12 +2286,12 @@ checksum = "a2b8b99d4cdbf36b239a9532e31fe4fb8acc38d1897c1761e161550a7dc78e6a"
 dependencies = [
  "assert-json-diff",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "deadpool",
  "futures",
- "http",
+ "http 1.3.1",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "log",
  "once_cell",
@@ -1907,7 +2308,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -1948,17 +2349,17 @@ checksum = "4ed5f19242090128c5809f6535cc7b8d4e2c32433f6c6005800bbc20a644a7f0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "futures",
- "http",
+ "http 1.3.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "log",
  "percent-encoding",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.23.28",
+ "rustls-pemfile 2.2.0",
  "seahash",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["serde", "v4"] }
-google-sheets4 = "6"
+reqwest = { version = "0.11", features = ["json", "rustls-tls"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 clap = { version = "4", features = ["derive"] }
 toml = "0.8"

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ optionally specify the worksheet name when creating the adapter; otherwise, it
 defaults to `Ledger`:
 
 ```rust,no_run
-use rusty_ledger::cloud_adapters::{GoogleSheets4Adapter, HyperConnector};
-use google_sheets4::{hyper_rustls, hyper_util, yup_oauth2, Sheets};
+use rusty_ledger::cloud_adapters::GoogleSheets4Adapter;
+use yup_oauth2::{self, InstalledFlowAuthenticator, InstalledFlowReturnMethod};
 
 async fn example() -> Result<(), Box<dyn std::error::Error>> {
     let secret = yup_oauth2::read_application_secret("client_secret.json").await?;
@@ -68,17 +68,7 @@ async fn example() -> Result<(), Box<dyn std::error::Error>> {
     .build()
     .await?;
 
-    let connector: HyperConnector = hyper_rustls::HttpsConnectorBuilder::new()
-        .with_native_roots()
-        .https_or_http()
-        .enable_http1()
-        .build();
-    let client = hyper_util::client::legacy::Client::builder(
-        hyper_util::rt::TokioExecutor::new(),
-    )
-    .build(connector.clone());
-    let hub = Sheets::new(client, auth);
-    let mut service = GoogleSheets4Adapter::with_sheet_name(hub, "Custom");
+    let mut service = GoogleSheets4Adapter::with_sheet_name(auth, "Custom");
     let sheet_id = service.create_sheet("ledger")?;
     service.append_row(&sheet_id, vec!["hello".into()])?;
     Ok(())

--- a/src/cloud_adapters/auth.rs
+++ b/src/cloud_adapters/auth.rs
@@ -154,7 +154,6 @@ pub async fn initial_oauth_login(
     credentials_path: &str,
     token_path: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    use google_sheets4::api::Scope;
     use yup_oauth2::{InstalledFlowAuthenticator, InstalledFlowReturnMethod};
 
     if !std::path::Path::new(credentials_path).exists() {
@@ -174,7 +173,10 @@ pub async fn initial_oauth_login(
         .build()
         .await?;
     let _ = auth
-        .token(&[Scope::DriveFile.as_ref(), Scope::Spreadsheet.as_ref()])
+        .token(&[
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/spreadsheets",
+        ])
         .await?;
     Ok(())
 }

--- a/src/cloud_adapters/google_sheets4.rs
+++ b/src/cloud_adapters/google_sheets4.rs
@@ -1,228 +1,308 @@
 use crate::cloud_adapters::{CloudSpreadsheetService, SpreadsheetError};
-use google_sheets4::{
-    self as sheets4, Sheets,
-    api::{Spreadsheet, SpreadsheetProperties, ValueRange},
-    hyper_rustls, hyper_util,
-};
+use reqwest::Client;
+use serde_json::json;
+use std::future::Future;
+use std::pin::Pin;
 
-use google_sheets4::common::Body;
-use hyper_util::client::legacy::connect::HttpConnector;
+/// Asynchronous token retrieval interface used by the adapter.
+pub trait TokenProvider: Send + Sync + 'static {
+    fn token<'a>(
+        &'a self,
+        scopes: &'a [&str],
+    ) -> Pin<Box<dyn Future<Output = Result<String, SpreadsheetError>> + Send + 'a>>;
+}
 
-/// Connector and client types used with the Sheets hub.
-pub type HyperConnector = hyper_rustls::HttpsConnector<HttpConnector>;
-pub type HyperClient = hyper_util::client::legacy::Client<HyperConnector, Body>;
+impl TokenProvider for yup_oauth2::authenticator::DefaultAuthenticator {
+    fn token<'a>(
+        &'a self,
+        scopes: &'a [&str],
+    ) -> Pin<Box<dyn Future<Output = Result<String, SpreadsheetError>> + Send + 'a>> {
+        Box::pin(async move {
+            self.token(scopes)
+                .await
+                .map_err(|e| SpreadsheetError::Transient(e.to_string()))?
+                .token()
+                .map(|t| t.to_string())
+                .ok_or_else(|| SpreadsheetError::Transient("missing token".into()))
+        })
+    }
+}
 
-/// Adapter backed by the real Google Sheets API.
+/// Adapter backed by the Google Sheets REST API.
 pub struct GoogleSheets4Adapter {
-    hub: Sheets<HyperConnector>,
+    client: Client,
+    auth: Box<dyn TokenProvider>,
     rt: tokio::runtime::Runtime,
     drive_base_url: String,
+    sheets_base_url: String,
     sheet_name: String,
 }
 
 impl GoogleSheets4Adapter {
-    /// Create a new adapter from an authenticated `Sheets` hub.
-    pub fn new(hub: Sheets<HyperConnector>) -> Self {
-        Self::with_drive_base_url_and_sheet_name(
-            hub,
+    /// Create a new adapter using default API endpoints.
+    pub fn new<A: TokenProvider>(auth: A) -> Self {
+        Self::with_base_urls_and_sheet_name(
+            auth,
             "https://www.googleapis.com/drive/v3/",
+            "https://sheets.googleapis.com/v4/",
             "Ledger",
         )
     }
 
-    /// Create a new adapter with a custom Drive API base URL (useful for tests).
-    pub fn with_drive_base_url(
-        hub: Sheets<HyperConnector>,
+    /// Create an adapter with a custom Drive base URL.
+    pub fn with_drive_base_url<A: TokenProvider>(
+        auth: A,
         drive_base_url: impl Into<String>,
     ) -> Self {
-        Self::with_drive_base_url_and_sheet_name(hub, drive_base_url, "Ledger")
+        Self::with_base_urls_and_sheet_name(
+            auth,
+            drive_base_url,
+            "https://sheets.googleapis.com/v4/",
+            "Ledger",
+        )
     }
 
-    /// Create a new adapter with a custom sheet name.
-    pub fn with_sheet_name(hub: Sheets<HyperConnector>, sheet_name: impl Into<String>) -> Self {
-        Self::with_drive_base_url_and_sheet_name(
-            hub,
+    /// Create an adapter with a custom sheet name.
+    pub fn with_sheet_name<A: TokenProvider>(auth: A, sheet_name: impl Into<String>) -> Self {
+        Self::with_base_urls_and_sheet_name(
+            auth,
             "https://www.googleapis.com/drive/v3/",
+            "https://sheets.googleapis.com/v4/",
             sheet_name,
         )
     }
 
-    /// Create a new adapter with a custom Drive API base URL and sheet name.
-    pub fn with_drive_base_url_and_sheet_name(
-        hub: Sheets<HyperConnector>,
+    /// Create an adapter with custom base URLs and sheet name.
+    pub fn with_base_urls_and_sheet_name<A: TokenProvider>(
+        auth: A,
         drive_base_url: impl Into<String>,
+        sheets_base_url: impl Into<String>,
         sheet_name: impl Into<String>,
     ) -> Self {
-        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
         Self {
-            hub,
-            rt,
+            client: Client::new(),
+            auth: Box::new(auth),
+            rt: tokio::runtime::Runtime::new().expect("tokio runtime"),
             drive_base_url: drive_base_url.into(),
+            sheets_base_url: sheets_base_url.into(),
             sheet_name: sheet_name.into(),
         }
     }
 
-    fn ensure_sheet(&self, sheet_id: &str) -> Result<(), SpreadsheetError> {
-        use sheets4::api::{
-            AddSheetRequest, BatchUpdateSpreadsheetRequest, Request as BatchRequest,
-            SheetProperties,
-        };
-        let fut = self.hub.spreadsheets().get(sheet_id).doit();
-        let res = self.rt.block_on(fut).map_err(Self::map_err)?;
-        let exists = res
-            .1
-            .sheets
-            .as_ref()
-            .map(|sheets| {
-                sheets.iter().any(|s| {
-                    s.properties.as_ref().and_then(|p| p.title.as_deref())
-                        == Some(self.sheet_name.as_str())
-                })
+    async fn get_token(&self, scopes: &[&str]) -> Result<String, SpreadsheetError> {
+        self.auth.token(scopes).await
+    }
+
+    async fn ensure_sheet(&self, sheet_id: &str) -> Result<(), SpreadsheetError> {
+        let token = self
+            .get_token(&["https://www.googleapis.com/auth/spreadsheets"])
+            .await?;
+        let url = format!("{}spreadsheets/{}", self.sheets_base_url, sheet_id);
+        let res = self
+            .client
+            .get(&url)
+            .bearer_auth(&token)
+            .send()
+            .await
+            .map_err(|e| SpreadsheetError::Transient(e.to_string()))?;
+        let exists = if res.status().is_success() {
+            let body: serde_json::Value = res
+                .json()
+                .await
+                .map_err(|e| SpreadsheetError::Transient(e.to_string()))?;
+            body["sheets"].as_array().is_some_and(|sheets| {
+                sheets
+                    .iter()
+                    .any(|s| s["properties"]["title"].as_str() == Some(self.sheet_name.as_str()))
             })
-            .unwrap_or(false);
+        } else {
+            false
+        };
         if exists {
             return Ok(());
         }
 
-        let add_sheet = BatchUpdateSpreadsheetRequest {
-            requests: Some(vec![BatchRequest {
-                add_sheet: Some(AddSheetRequest {
-                    properties: Some(SheetProperties {
-                        title: Some(self.sheet_name.clone()),
-                        ..Default::default()
-                    }),
-                }),
-                ..Default::default()
-            }]),
-            ..Default::default()
-        };
-        let fut = self
-            .hub
-            .spreadsheets()
-            .batch_update(add_sheet, sheet_id)
-            .doit();
-        self.rt.block_on(fut).map_err(Self::map_err)?;
-        Ok(())
-    }
-
-    fn map_err(err: sheets4::Error) -> SpreadsheetError {
-        use sheets4::Error::*;
-        match err {
-            HttpError(_) | Io(_) | Failure(_) => SpreadsheetError::Transient(err.to_string()),
-            _ => SpreadsheetError::Permanent(err.to_string()),
+        let update_url = format!(
+            "{}spreadsheets/{}:batchUpdate",
+            self.sheets_base_url, sheet_id
+        );
+        let body = json!({
+            "requests": [{"addSheet": {"properties": {"title": self.sheet_name}}}]
+        });
+        let res = self
+            .client
+            .post(&update_url)
+            .bearer_auth(&token)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| SpreadsheetError::Transient(e.to_string()))?;
+        if res.status().is_success() {
+            Ok(())
+        } else {
+            Err(SpreadsheetError::Transient("batch update failed".into()))
         }
     }
 }
 
 impl CloudSpreadsheetService for GoogleSheets4Adapter {
     fn create_sheet(&mut self, title: &str) -> Result<String, SpreadsheetError> {
-        let req = Spreadsheet {
-            properties: Some(SpreadsheetProperties {
-                title: Some(title.to_string()),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        let fut = self.hub.spreadsheets().create(req).doit();
-        let res = self.rt.block_on(fut).map_err(Self::map_err)?;
-        let id = res.1.spreadsheet_id.unwrap_or_default();
-        self.ensure_sheet(&id)?;
-        Ok(id)
+        self.rt.block_on(async {
+            let token = self
+                .get_token(&["https://www.googleapis.com/auth/spreadsheets"])
+                .await?;
+            let url = format!("{}spreadsheets", self.sheets_base_url);
+            let body = json!({"properties": {"title": title}});
+            let res = self
+                .client
+                .post(&url)
+                .bearer_auth(&token)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| SpreadsheetError::Transient(e.to_string()))?;
+            if !res.status().is_success() {
+                return Err(SpreadsheetError::Transient("create failed".into()));
+            }
+            let body: serde_json::Value = res
+                .json()
+                .await
+                .map_err(|e| SpreadsheetError::Transient(e.to_string()))?;
+            let id = body["spreadsheetId"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string();
+            self.ensure_sheet(&id).await?;
+            Ok(id)
+        })
     }
 
     fn append_row(&mut self, sheet_id: &str, values: Vec<String>) -> Result<(), SpreadsheetError> {
-        self.ensure_sheet(sheet_id)?;
-        let row = values.into_iter().map(serde_json::Value::String).collect();
-        let req = ValueRange {
-            values: Some(vec![row]),
-            ..Default::default()
-        };
-        let fut = self
-            .hub
-            .spreadsheets()
-            .values_append(req, sheet_id, &self.sheet_name)
-            .value_input_option("USER_ENTERED")
-            .doit();
-        self.rt.block_on(fut).map_err(Self::map_err)?;
-        Ok(())
+        self.rt.block_on(async {
+            self.ensure_sheet(sheet_id).await?;
+            let token = self
+                .get_token(&["https://www.googleapis.com/auth/spreadsheets"])
+                .await?;
+            let url = format!(
+                "{}spreadsheets/{}/values/{}:append?valueInputOption=USER_ENTERED",
+                self.sheets_base_url, sheet_id, self.sheet_name
+            );
+            let row: Vec<serde_json::Value> =
+                values.into_iter().map(serde_json::Value::String).collect();
+            let body = json!({"values": [row]});
+            let res = self
+                .client
+                .post(&url)
+                .bearer_auth(&token)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| SpreadsheetError::Transient(e.to_string()))?;
+            if res.status().is_success() {
+                Ok(())
+            } else {
+                Err(SpreadsheetError::Transient("append failed".into()))
+            }
+        })
     }
 
     fn read_row(&self, sheet_id: &str, index: usize) -> Result<Vec<String>, SpreadsheetError> {
-        self.ensure_sheet(sheet_id)?;
-        let range = format!("{}!A{}:Z{}", self.sheet_name, index + 1, index + 1);
-        let fut = self.hub.spreadsheets().values_get(sheet_id, &range).doit();
-        let res = self.rt.block_on(fut).map_err(Self::map_err)?;
-        let rows = res.1.values.unwrap_or_default();
-        let row = rows
-            .into_iter()
-            .next()
-            .ok_or(SpreadsheetError::RowNotFound)?;
-        Ok(row
-            .into_iter()
-            .map(|v| v.as_str().unwrap_or_default().to_string())
-            .collect())
+        self.rt.block_on(async {
+            self.ensure_sheet(sheet_id).await?;
+            let token = self
+                .get_token(&["https://www.googleapis.com/auth/spreadsheets"])
+                .await?;
+            let range = format!("{}!A{}:Z{}", self.sheet_name, index + 1, index + 1);
+            let url = format!(
+                "{}spreadsheets/{}/values/{}",
+                self.sheets_base_url, sheet_id, range
+            );
+            let res = self
+                .client
+                .get(&url)
+                .bearer_auth(&token)
+                .send()
+                .await
+                .map_err(|e| SpreadsheetError::Transient(e.to_string()))?;
+            if !res.status().is_success() {
+                return Err(SpreadsheetError::RowNotFound);
+            }
+            let body: serde_json::Value = res
+                .json()
+                .await
+                .map_err(|e| SpreadsheetError::Transient(e.to_string()))?;
+            let row = body["values"]
+                .as_array()
+                .and_then(|arr| arr.first())
+                .cloned();
+            let row = row.ok_or(SpreadsheetError::RowNotFound)?;
+            Ok(row
+                .as_array()
+                .unwrap_or(&vec![])
+                .iter()
+                .map(|v| v.as_str().unwrap_or_default().to_string())
+                .collect())
+        })
     }
 
     fn list_rows(&self, sheet_id: &str) -> Result<Vec<Vec<String>>, SpreadsheetError> {
-        self.ensure_sheet(sheet_id)?;
-        let fut = self
-            .hub
-            .spreadsheets()
-            .values_get(sheet_id, &self.sheet_name)
-            .doit();
-        let res = self.rt.block_on(fut).map_err(Self::map_err)?;
-        let rows = res.1.values.unwrap_or_default();
-        Ok(rows
-            .into_iter()
-            .map(|row| {
-                row.into_iter()
-                    .map(|v| v.as_str().unwrap_or_default().to_string())
-                    .collect()
-            })
-            .collect())
+        self.rt.block_on(async {
+            self.ensure_sheet(sheet_id).await?;
+            let token = self
+                .get_token(&["https://www.googleapis.com/auth/spreadsheets"])
+                .await?;
+            let url = format!(
+                "{}spreadsheets/{}/values/{}",
+                self.sheets_base_url, sheet_id, self.sheet_name
+            );
+            let res = self
+                .client
+                .get(&url)
+                .bearer_auth(&token)
+                .send()
+                .await
+                .map_err(|e| SpreadsheetError::Transient(e.to_string()))?;
+            if !res.status().is_success() {
+                return Err(SpreadsheetError::Transient("list failed".into()));
+            }
+            let body: serde_json::Value = res
+                .json()
+                .await
+                .map_err(|e| SpreadsheetError::Transient(e.to_string()))?;
+            let rows = body["values"].as_array().cloned().unwrap_or_default();
+            Ok(rows
+                .into_iter()
+                .map(|row| {
+                    row.as_array()
+                        .unwrap_or(&vec![])
+                        .iter()
+                        .map(|v| v.as_str().unwrap_or_default().to_string())
+                        .collect()
+                })
+                .collect())
+        })
     }
 
     fn share_sheet(&self, sheet_id: &str, email: &str) -> Result<(), SpreadsheetError> {
-        use google_sheets4::hyper::header::{
-            AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, USER_AGENT,
-        };
-        use google_sheets4::hyper::{Method, Request};
-        use serde_json::json;
-
-        let drive_url = format!("{}files/{}/permissions", self.drive_base_url, sheet_id);
-
-        let fut = async {
+        self.rt.block_on(async {
             let token = self
-                .hub
-                .auth
                 .get_token(&["https://www.googleapis.com/auth/drive"])
+                .await?;
+            let url = format!("{}files/{}/permissions", self.drive_base_url, sheet_id);
+            let body = json!({"type": "user", "role": "writer", "emailAddress": email});
+            let res = self
+                .client
+                .post(&url)
+                .bearer_auth(&token)
+                .json(&body)
+                .send()
                 .await
-                .map_err(|_| SpreadsheetError::ShareFailed)?
-                .ok_or(SpreadsheetError::ShareFailed)?;
-
-            let body_json = json!({
-                "type": "user",
-                "role": "writer",
-                "emailAddress": email,
-            });
-            let body =
-                serde_json::to_vec(&body_json).expect("failed to serialize permission request");
-            let req = Request::builder()
-                .method(Method::POST)
-                .uri(&drive_url)
-                .header(USER_AGENT, "rusty-ledger")
-                .header(AUTHORIZATION, format!("Bearer {}", token))
-                .header(CONTENT_TYPE, "application/json")
-                .header(CONTENT_LENGTH, body.len() as u64)
-                .body(google_sheets4::common::to_body(Some(body)))
-                .expect("failed to build permission request");
-
-            match self.hub.client.request(req).await {
-                Ok(res) if res.status().is_success() => Ok(()),
-                _ => Err(SpreadsheetError::ShareFailed),
+                .map_err(|e| SpreadsheetError::Transient(e.to_string()))?;
+            if res.status().is_success() {
+                Ok(())
+            } else {
+                Err(SpreadsheetError::ShareFailed)
             }
-        };
-
-        self.rt.block_on(fut)
+        })
     }
 }

--- a/src/cloud_adapters/mod.rs
+++ b/src/cloud_adapters/mod.rs
@@ -6,7 +6,7 @@ pub use retry::RetryingService;
 pub mod buffered;
 pub use buffered::{BatchingCacheService, EvictionPolicy};
 pub mod google_sheets4;
-pub use google_sheets4::{GoogleSheets4Adapter, HyperClient};
+pub use google_sheets4::GoogleSheets4Adapter;
 
 use std::collections::HashMap;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use clap::{Args, Parser, Subcommand};
-use google_sheets4::{Sheets, hyper_rustls, hyper_util};
-use rusty_ledger::cloud_adapters::{
-    CloudSpreadsheetService,
-    google_sheets4::{GoogleSheets4Adapter, HyperClient, HyperConnector},
-};
+use rusty_ledger::cloud_adapters::{CloudSpreadsheetService, google_sheets4::GoogleSheets4Adapter};
 use rusty_ledger::core::Record;
 use rusty_ledger::import;
 use serde::{Deserialize, Serialize};
@@ -190,18 +186,9 @@ async fn adapter_from_config(
         .build()
         .await?;
 
-    let connector: HyperConnector = hyper_rustls::HttpsConnectorBuilder::new()
-        .with_native_roots()?
-        .https_or_http()
-        .enable_http1()
-        .build();
-    let client: HyperClient =
-        hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
-            .build(connector.clone());
-    let hub = Sheets::new(client, auth);
     let adapter = match &cfg.sheet_name {
-        Some(name) => GoogleSheets4Adapter::with_sheet_name(hub, name.clone()),
-        None => GoogleSheets4Adapter::new(hub),
+        Some(name) => GoogleSheets4Adapter::with_sheet_name(auth, name.clone()),
+        None => GoogleSheets4Adapter::new(auth),
     };
     Ok(adapter)
 }

--- a/tests/google_sheet_name_tests.rs
+++ b/tests/google_sheet_name_tests.rs
@@ -1,28 +1,24 @@
-use rusty_ledger::cloud_adapters::google_sheets4::HyperConnector;
-use rusty_ledger::cloud_adapters::{CloudSpreadsheetService, GoogleSheets4Adapter};
+use rusty_ledger::cloud_adapters::google_sheets4::TokenProvider;
+use rusty_ledger::cloud_adapters::{
+    CloudSpreadsheetService, GoogleSheets4Adapter, SpreadsheetError,
+};
 
 #[derive(Clone)]
 struct StaticToken;
 
-impl google_sheets4::common::GetToken for StaticToken {
-    fn get_token<'a>(
+impl TokenProvider for StaticToken {
+    fn token<'a>(
         &'a self,
         _scopes: &'a [&str],
     ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<
-                    Output = Result<Option<String>, Box<dyn std::error::Error + Send + Sync>>,
-                > + Send
-                + 'a,
-        >,
+        Box<dyn std::future::Future<Output = Result<String, SpreadsheetError>> + Send + 'a>,
     > {
-        Box::pin(async { Ok(Some("test-token".to_string())) })
+        Box::pin(async { Ok("test-token".to_string()) })
     }
 }
 
 #[tokio::test]
 async fn ensures_sheet_exists() {
-    use google_sheets4::{Sheets, hyper_rustls, hyper_util};
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -42,20 +38,12 @@ async fn ensures_sheet_exists() {
         .mount(&server)
         .await;
 
-    let connector: HyperConnector = hyper_rustls::HttpsConnectorBuilder::new()
-        .with_native_roots()
-        .unwrap()
-        .https_or_http()
-        .enable_http1()
-        .build();
-    let client = hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
-        .build(connector.clone());
-    let mut hub = Sheets::new(client, StaticToken);
-    let base = format!("{}/", server.uri());
-    hub.base_url(base.clone());
-    hub.root_url(base);
-
-    let mut adapter = GoogleSheets4Adapter::with_sheet_name(hub, "Custom");
+    let mut adapter = GoogleSheets4Adapter::with_base_urls_and_sheet_name(
+        StaticToken,
+        format!("{}/", server.uri()),
+        format!("{}/v4/", server.uri()),
+        "Custom",
+    );
     let result =
         tokio::task::spawn_blocking(move || adapter.append_row("sheet123", vec!["hello".into()]))
             .await


### PR DESCRIPTION
## Summary
- drop the `google-sheets4` crate and implement API calls via `reqwest`
- add a small token provider trait for retrieving OAuth tokens
- update adapter construction and CLI to use the new API
- adjust tests for the new adapter interface
- update README example for the new approach

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_685dba686b34832aad23a541b5d34336