### PR TITLE
Replace qif crate with manual parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,17 +1010,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "qif"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e61f755606130439830f7dbc00d366dae6c511659c5b436d22e75e1cc46c52"
-dependencies = [
- "chrono",
- "regex",
- "unicode-segmentation",
-]
-
-[[package]]
 name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,7 +1195,6 @@ dependencies = [
  "csv",
  "hyper 0.14.32",
  "hyper-rustls 0.24.2",
- "qif",
  "quick-xml",
  "serde",
  "serde_json",
@@ -1572,12 +1560,6 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ clap = { version = "4", features = ["derive"] }
 toml = "0.8"
 yup-oauth2 = "11"
 csv = "1"
-qif = "0.1"
 quick-xml = "0.37"
 
 [dev-dependencies]

--- a/tests/import_tests.rs
+++ b/tests/import_tests.rs
@@ -33,6 +33,17 @@ fn qif_parsing() {
 }
 
 #[test]
+fn qif_memo_overrides_vendor() {
+    let qif_content = "!Type:Bank\nD01/02/2024\nT5.00\nPVend\nMMemo text\n^\n";
+    let path = write_temp("memo.qif", qif_content);
+    let records = qif::parse(&path).unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].description, "Memo text");
+    assert_eq!(records[0].amount, 5.0);
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
 fn ofx_parsing() {
     let ofx_content = r#"<OFX><BANKMSGSRSV1><STMTTRNRS><STMTRS><BANKTRANLIST>
 <STMTTRN><TRNAMT>-7.00</TRNAMT><NAME>Snack</NAME></STMTTRN>


### PR DESCRIPTION
## Summary
- drop the `qif` dependency
- implement a small QIF parser for the bank records
- ensure QIF parsing still works and add test for memo precedence

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_685dcb0b0d58832ab50663c40991313f