### PR TITLE
Remove quick-xml and manual OFX parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,15 +1010,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-xml"
-version = "0.37.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,7 +1186,6 @@ dependencies = [
  "csv",
  "hyper 0.14.32",
  "hyper-rustls 0.24.2",
- "quick-xml",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ clap = { version = "4", features = ["derive"] }
 toml = "0.8"
 yup-oauth2 = "11"
 csv = "1"
-quick-xml = "0.37"
 
 [dev-dependencies]
 wiremock = "0.6"


### PR DESCRIPTION
## Summary
- drop quick-xml dependency
- rewrite OFX import parser using string search
- keep OFX test coverage

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_685dce48f638832aa14c57650fafb245