### PR TITLE
Add currency validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,6 +841,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "iso_country"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20633e788d3948ea7336861fdb09ec247f5dae4267e8f0743fa97de26c28624d"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "iso_currency"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed4b3f0921193400b1df556228bfd917c57c7fa38bda904d552653c5c3b641b"
+dependencies = [
+ "iso_country",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,6 +875,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -1180,6 +1206,7 @@ dependencies = [
  "csv",
  "hyper 0.14.32",
  "hyper-rustls 0.24.2",
+ "iso_currency",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ clap = { version = "4", features = ["derive"] }
 toml = "0.8"
 yup-oauth2 = "12"
 csv = "1"
+iso_currency = "0.5"
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,6 +1,7 @@
 //! Core logic for the append-only immutable database.
 
 use chrono::{DateTime, Utc};
+use iso_currency::Currency;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -14,6 +15,8 @@ pub enum RecordError {
     SameAccount,
     /// The amount provided is not positive.
     NonPositiveAmount,
+    /// The provided currency code is not supported.
+    UnsupportedCurrency(String),
 }
 
 impl std::fmt::Display for RecordError {
@@ -24,6 +27,9 @@ impl std::fmt::Display for RecordError {
             }
             RecordError::NonPositiveAmount => {
                 write!(f, "transaction amount must be greater than zero")
+            }
+            RecordError::UnsupportedCurrency(code) => {
+                write!(f, "unsupported currency code: {code}")
             }
         }
     }
@@ -74,6 +80,9 @@ impl Record {
         }
         if amount <= 0.0 {
             return Err(RecordError::NonPositiveAmount);
+        }
+        if Currency::from_code(&currency).is_none() {
+            return Err(RecordError::UnsupportedCurrency(currency));
         }
 
         Ok(Self {

--- a/tests/ledger_tests.rs
+++ b/tests/ledger_tests.rs
@@ -239,3 +239,31 @@ fn record_creation_rejects_nonpositive_amounts() {
     .unwrap_err();
     assert_eq!(negative_err, RecordError::NonPositiveAmount);
 }
+
+#[test]
+fn record_creation_validates_currency() {
+    let valid = Record::new(
+        "ok".into(),
+        "cash".into(),
+        "revenue".into(),
+        1.0,
+        "USD".into(),
+        None,
+        None,
+        vec![],
+    );
+    assert!(valid.is_ok());
+
+    let invalid = Record::new(
+        "bad".into(),
+        "cash".into(),
+        "revenue".into(),
+        1.0,
+        "ZZZ".into(),
+        None,
+        None,
+        vec![],
+    )
+    .unwrap_err();
+    assert_eq!(invalid, RecordError::UnsupportedCurrency("ZZZ".into()));
+}


### PR DESCRIPTION
## Summary
- add `iso_currency` crate
- return `UnsupportedCurrency` from `Record::new`
- test valid and invalid currency codes

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_685ddb2dd298832a9ebb02edc659d45a