### PR TITLE
Add hierarchical account aggregation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,3 +6,6 @@ Rusty Ledger is organized into two main modules:
 - **cloud_adapters** – Contains implementations for interacting with remote spreadsheet services. Adapters implement the `CloudSpreadsheetService` trait and can be wrapped with utilities like batching and retry logic.
 
 Each module exposes a minimal surface area so that applications can choose the pieces they need. The `lib.rs` file simply re-exports these modules.
+
+The core module defines an `Account` type that stores hierarchical names like `Assets:Bank:Checking`.
+Ledger helper methods can aggregate balances across subaccounts using this structure.

--- a/src/core/account.rs
+++ b/src/core/account.rs
@@ -1,0 +1,55 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as DeError};
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Account {
+    parts: Vec<String>,
+}
+
+impl Serialize for Account {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for Account {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Account::from_str(&s).map_err(DeError::custom)
+    }
+}
+
+impl FromStr for Account {
+    type Err = std::convert::Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self {
+            parts: if s.is_empty() {
+                Vec::new()
+            } else {
+                s.split(':').map(|p| p.to_string()).collect()
+            },
+        })
+    }
+}
+
+impl fmt::Display for Account {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.parts.join(":"))
+    }
+}
+
+impl Account {
+    pub fn starts_with(&self, other: &Account) -> bool {
+        if other.parts.len() > self.parts.len() {
+            return false;
+        }
+        self.parts.iter().zip(&other.parts).all(|(a, b)| a == b)
+    }
+}

--- a/src/core/query.rs
+++ b/src/core/query.rs
@@ -79,8 +79,9 @@ impl Query {
             }
         }
         if !self.accounts.is_empty()
-            && !self.accounts.contains(&rec.debit_account)
-            && !self.accounts.contains(&rec.credit_account)
+            && !self.accounts.iter().any(|a| {
+                a == &rec.debit_account.to_string() || a == &rec.credit_account.to_string()
+            })
         {
             return false;
         }
@@ -115,8 +116,8 @@ mod tests {
         let mut ledger = Ledger::default();
         let mut rec = Record::new(
             "coffee".into(),
-            "expenses".into(),
-            "cash".into(),
+            "expenses".parse().unwrap(),
+            "cash".parse().unwrap(),
             3.0,
             "USD".into(),
             None,
@@ -128,8 +129,8 @@ mod tests {
         ledger.commit(rec);
         let mut rec2 = Record::new(
             "rent".into(),
-            "expenses".into(),
-            "cash".into(),
+            "expenses".parse().unwrap(),
+            "cash".parse().unwrap(),
             100.0,
             "USD".into(),
             None,

--- a/src/core/sharing.rs
+++ b/src/core/sharing.rs
@@ -130,8 +130,12 @@ impl<S: CloudSpreadsheetService> SharedLedger<S> {
             id,
             timestamp,
             description: row[2].clone(),
-            debit_account: row[3].clone(),
-            credit_account: row[4].clone(),
+            debit_account: row[3]
+                .parse()
+                .map_err(|e| SpreadsheetError::Permanent(format!("invalid account: {e}")))?,
+            credit_account: row[4]
+                .parse()
+                .map_err(|e| SpreadsheetError::Permanent(format!("invalid account: {e}")))?,
             amount,
             currency: row[6].clone(),
             reference_id,

--- a/src/import/csv.rs
+++ b/src/import/csv.rs
@@ -56,10 +56,20 @@ impl CsvImporter {
                 .ok_or_else(|| ImportError::Parse("missing amount".into()))?
                 .parse::<f64>()
                 .map_err(|e: std::num::ParseFloatError| ImportError::Parse(e.to_string()))?;
+            let debit_acc = row
+                .get(debit_idx)
+                .unwrap_or_default()
+                .parse()
+                .map_err(|_| ImportError::Parse("invalid account".into()))?;
+            let credit_acc = row
+                .get(credit_idx)
+                .unwrap_or_default()
+                .parse()
+                .map_err(|_| ImportError::Parse("invalid account".into()))?;
             let rec = Record::new(
                 row.get(desc_idx).unwrap_or_default().to_string(),
-                row.get(debit_idx).unwrap_or_default().to_string(),
-                row.get(credit_idx).unwrap_or_default().to_string(),
+                debit_acc,
+                credit_acc,
                 amount_val,
                 row.get(currency_idx).unwrap_or_default().to_string(),
                 None,

--- a/src/import/ofx.rs
+++ b/src/import/ofx.rs
@@ -36,8 +36,8 @@ impl OfxImporter {
                 };
                 let rec = Record::new(
                     name.trim().to_string(),
-                    debit,
-                    credit,
+                    debit.parse().unwrap(),
+                    credit.parse().unwrap(),
                     amount.abs(),
                     "USD".into(),
                     None,

--- a/src/import/qif.rs
+++ b/src/import/qif.rs
@@ -45,8 +45,8 @@ impl QifImporter {
                     };
                     let rec = Record::new(
                         desc,
-                        debit,
-                        credit,
+                        debit.parse().unwrap(),
+                        credit.parse().unwrap(),
                         a.abs(),
                         "USD".into(),
                         None,

--- a/tests/access_control_tests.rs
+++ b/tests/access_control_tests.rs
@@ -11,8 +11,8 @@ fn reader_cannot_write() {
 
     let record = Record::new(
         "desc".into(),
-        "cash".into(),
-        "revenue".into(),
+        "cash".parse().unwrap(),
+        "revenue".parse().unwrap(),
         1.0,
         "USD".into(),
         None,
@@ -35,8 +35,8 @@ fn writer_can_write() {
 
     let record = Record::new(
         "desc".into(),
-        "cash".into(),
-        "revenue".into(),
+        "cash".parse().unwrap(),
+        "revenue".parse().unwrap(),
         2.0,
         "USD".into(),
         None,
@@ -57,8 +57,8 @@ fn access_is_required_for_reads() {
 
     let record = Record::new(
         "desc".into(),
-        "cash".into(),
-        "revenue".into(),
+        "cash".parse().unwrap(),
+        "revenue".parse().unwrap(),
         3.0,
         "USD".into(),
         None,

--- a/tests/import_tests.rs
+++ b/tests/import_tests.rs
@@ -15,8 +15,8 @@ fn csv_parsing() {
     assert_eq!(records.len(), 1);
     let r = &records[0];
     assert_eq!(r.description, "Coffee");
-    assert_eq!(r.debit_account, "expenses:food");
-    assert_eq!(r.credit_account, "cash");
+    assert_eq!(r.debit_account.to_string(), "expenses:food");
+    assert_eq!(r.credit_account.to_string(), "cash");
     assert_eq!(r.amount, 3.50);
     let _ = std::fs::remove_file(path);
 }
@@ -71,8 +71,8 @@ fn csv_parsing_with_mapping() {
     assert_eq!(records.len(), 1);
     let r = &records[0];
     assert_eq!(r.description, "Coffee");
-    assert_eq!(r.debit_account, "expenses:food");
-    assert_eq!(r.credit_account, "cash");
+    assert_eq!(r.debit_account.to_string(), "expenses:food");
+    assert_eq!(r.credit_account.to_string(), "cash");
     assert_eq!(r.amount, 4.20);
     let _ = std::fs::remove_file(path);
 }

--- a/tests/ledger_tests.rs
+++ b/tests/ledger_tests.rs
@@ -1,5 +1,5 @@
 use chrono::{NaiveDate, TimeZone, Utc};
-use rusty_ledger::core::{Ledger, LedgerError, PriceDatabase, Record, RecordError};
+use rusty_ledger::core::{Account, Ledger, LedgerError, PriceDatabase, Record, RecordError};
 use uuid::Uuid;
 
 #[test]
@@ -8,8 +8,8 @@ fn records_are_appended() {
     ledger.commit(
         Record::new(
             "data".into(),
-            "cash".into(),
-            "revenue".into(),
+            "cash".parse().unwrap(),
+            "revenue".parse().unwrap(),
             1.0,
             "USD".into(),
             None,
@@ -26,8 +26,8 @@ fn record_serialization_roundtrip() {
     let reference = Uuid::new_v4();
     let record = Record::new(
         "desc".into(),
-        "cash".into(),
-        "revenue".into(),
+        "cash".parse().unwrap(),
+        "revenue".parse().unwrap(),
         10.0,
         "USD".into(),
         Some(reference),
@@ -46,8 +46,8 @@ fn record_serialization_roundtrip() {
 fn record_creation_sets_fields() {
     let record = Record::new(
         "desc".into(),
-        "cash".into(),
-        "revenue".into(),
+        "cash".parse().unwrap(),
+        "revenue".parse().unwrap(),
         5.0,
         "USD".into(),
         None,
@@ -65,8 +65,8 @@ fn committed_record_can_be_retrieved() {
     let mut ledger = Ledger::default();
     let record = Record::new(
         "desc".into(),
-        "cash".into(),
-        "revenue".into(),
+        "cash".parse().unwrap(),
+        "revenue".parse().unwrap(),
         3.0,
         "USD".into(),
         None,
@@ -86,8 +86,8 @@ fn committed_records_are_immutable() {
     let mut ledger = Ledger::default();
     let record = Record::new(
         "desc".into(),
-        "cash".into(),
-        "revenue".into(),
+        "cash".parse().unwrap(),
+        "revenue".parse().unwrap(),
         4.0,
         "USD".into(),
         None,
@@ -103,8 +103,8 @@ fn committed_records_are_immutable() {
             id,
             Record::new(
                 "new".into(),
-                "cash".into(),
-                "revenue".into(),
+                "cash".parse().unwrap(),
+                "revenue".parse().unwrap(),
                 5.0,
                 "USD".into(),
                 None,
@@ -126,8 +126,8 @@ fn adjustment_chaining() {
 
     let original = Record::new(
         "orig".into(),
-        "cash".into(),
-        "revenue".into(),
+        "cash".parse().unwrap(),
+        "revenue".parse().unwrap(),
         10.0,
         "USD".into(),
         None,
@@ -140,8 +140,8 @@ fn adjustment_chaining() {
 
     let adj1 = Record::new(
         "adj1".into(),
-        "revenue".into(),
-        "cash".into(),
+        "revenue".parse().unwrap(),
+        "cash".parse().unwrap(),
         2.0,
         "USD".into(),
         None,
@@ -154,8 +154,8 @@ fn adjustment_chaining() {
 
     let adj2 = Record::new(
         "adj2".into(),
-        "cash".into(),
-        "revenue".into(),
+        "cash".parse().unwrap(),
+        "revenue".parse().unwrap(),
         1.0,
         "USD".into(),
         None,
@@ -181,8 +181,8 @@ fn adjustment_requires_existing_record() {
     let mut ledger = Ledger::default();
     let adj = Record::new(
         "adj".into(),
-        "cash".into(),
-        "revenue".into(),
+        "cash".parse().unwrap(),
+        "revenue".parse().unwrap(),
         1.0,
         "USD".into(),
         None,
@@ -200,8 +200,8 @@ fn adjustment_requires_existing_record() {
 fn record_creation_rejects_identical_accounts() {
     let err = Record::new(
         "desc".into(),
-        "cash".into(),
-        "cash".into(),
+        "cash".parse().unwrap(),
+        "cash".parse().unwrap(),
         1.0,
         "USD".into(),
         None,
@@ -216,8 +216,8 @@ fn record_creation_rejects_identical_accounts() {
 fn record_creation_rejects_nonpositive_amounts() {
     let zero_err = Record::new(
         "zero".into(),
-        "cash".into(),
-        "revenue".into(),
+        "cash".parse().unwrap(),
+        "revenue".parse().unwrap(),
         0.0,
         "USD".into(),
         None,
@@ -229,8 +229,8 @@ fn record_creation_rejects_nonpositive_amounts() {
 
     let negative_err = Record::new(
         "neg".into(),
-        "cash".into(),
-        "revenue".into(),
+        "cash".parse().unwrap(),
+        "revenue".parse().unwrap(),
         -1.0,
         "USD".into(),
         None,
@@ -245,8 +245,8 @@ fn record_creation_rejects_nonpositive_amounts() {
 fn record_creation_validates_currency() {
     let valid = Record::new(
         "ok".into(),
-        "cash".into(),
-        "revenue".into(),
+        "cash".parse().unwrap(),
+        "revenue".parse().unwrap(),
         1.0,
         "USD".into(),
         None,
@@ -257,8 +257,8 @@ fn record_creation_validates_currency() {
 
     let invalid = Record::new(
         "bad".into(),
-        "cash".into(),
-        "revenue".into(),
+        "cash".parse().unwrap(),
+        "revenue".parse().unwrap(),
         1.0,
         "ZZZ".into(),
         None,
@@ -275,8 +275,8 @@ fn account_balance_after_commits() {
     ledger.commit(
         Record::new(
             "first".into(),
-            "cash".into(),
-            "revenue".into(),
+            "cash".parse().unwrap(),
+            "revenue".parse().unwrap(),
             2.0,
             "USD".into(),
             None,
@@ -288,8 +288,8 @@ fn account_balance_after_commits() {
     ledger.commit(
         Record::new(
             "second".into(),
-            "cash".into(),
-            "revenue".into(),
+            "cash".parse().unwrap(),
+            "revenue".parse().unwrap(),
             3.0,
             "USD".into(),
             None,
@@ -310,8 +310,8 @@ fn account_balance_with_adjustments() {
 
     let original = Record::new(
         "orig".into(),
-        "cash".into(),
-        "revenue".into(),
+        "cash".parse().unwrap(),
+        "revenue".parse().unwrap(),
         10.0,
         "USD".into(),
         None,
@@ -324,8 +324,8 @@ fn account_balance_with_adjustments() {
 
     let adj1 = Record::new(
         "adj1".into(),
-        "revenue".into(),
-        "cash".into(),
+        "revenue".parse().unwrap(),
+        "cash".parse().unwrap(),
         2.0,
         "USD".into(),
         None,
@@ -338,8 +338,8 @@ fn account_balance_with_adjustments() {
 
     let adj2 = Record::new(
         "adj2".into(),
-        "cash".into(),
-        "revenue".into(),
+        "cash".parse().unwrap(),
+        "revenue".parse().unwrap(),
         1.0,
         "USD".into(),
         None,
@@ -359,8 +359,8 @@ fn account_balance_converts_currencies() {
     let mut ledger = Ledger::default();
     let mut eur = Record::new(
         "eur".into(),
-        "cash".into(),
-        "rev".into(),
+        "cash".parse().unwrap(),
+        "rev".parse().unwrap(),
         10.0,
         "EUR".into(),
         None,
@@ -372,8 +372,8 @@ fn account_balance_converts_currencies() {
     ledger.commit(eur);
     let mut usd = Record::new(
         "usd".into(),
-        "cash".into(),
-        "rev".into(),
+        "cash".parse().unwrap(),
+        "rev".parse().unwrap(),
         10.0,
         "USD".into(),
         None,
@@ -391,4 +391,38 @@ fn account_balance_converts_currencies() {
 
     assert_eq!(ledger.account_balance("cash", "USD", &prices), 30.0);
     assert_eq!(ledger.account_balance("cash", "EUR", &prices), 15.0);
+}
+
+#[test]
+fn account_tree_balance_nested_accounts() {
+    let mut ledger = Ledger::default();
+    ledger.commit(
+        Record::new(
+            "check".into(),
+            "Assets:Bank:Checking".parse().unwrap(),
+            "income".parse().unwrap(),
+            5.0,
+            "USD".into(),
+            None,
+            None,
+            vec![],
+        )
+        .unwrap(),
+    );
+    ledger.commit(
+        Record::new(
+            "save".into(),
+            "Assets:Bank:Savings".parse().unwrap(),
+            "income".parse().unwrap(),
+            2.0,
+            "USD".into(),
+            None,
+            None,
+            vec![],
+        )
+        .unwrap(),
+    );
+    let prices = PriceDatabase::default();
+    let parent: Account = "Assets:Bank".parse().unwrap();
+    assert_eq!(ledger.account_tree_balance(&parent, "USD", &prices), 7.0);
 }

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -16,8 +16,8 @@ fn filter_by_tag_and_date() {
     let mut ledger = Ledger::default();
     let mut rec1 = Record::new(
         "coffee".into(),
-        "expenses".into(),
-        "cash".into(),
+        "expenses".parse().unwrap(),
+        "cash".parse().unwrap(),
         3.0,
         "USD".into(),
         None,
@@ -30,8 +30,8 @@ fn filter_by_tag_and_date() {
 
     let mut rec2 = Record::new(
         "rent".into(),
-        "expenses".into(),
-        "cash".into(),
+        "expenses".parse().unwrap(),
+        "cash".parse().unwrap(),
         100.0,
         "USD".into(),
         None,

--- a/tests/shared_ledger_service_tests.rs
+++ b/tests/shared_ledger_service_tests.rs
@@ -76,8 +76,8 @@ fn commit_invokes_append_row() {
 
     let record = Record::new(
         "desc".into(),
-        "cash".into(),
-        "revenue".into(),
+        "cash".parse().unwrap(),
+        "revenue".parse().unwrap(),
         1.0,
         "USD".into(),
         None,
@@ -209,8 +209,8 @@ fn from_sheet_loads_existing_rows() {
     let sheet = adapter.create_sheet("ledger").unwrap();
     let record = Record::new(
         "desc".into(),
-        "cash".into(),
-        "revenue".into(),
+        "cash".parse().unwrap(),
+        "revenue".parse().unwrap(),
         2.0,
         "USD".into(),
         None,

--- a/tests/thread_safety_tests.rs
+++ b/tests/thread_safety_tests.rs
@@ -20,8 +20,8 @@ fn concurrent_commits() {
         handles.push(thread::spawn(move || {
             let record = Record::new(
                 "desc".into(),
-                "cash".into(),
-                "revenue".into(),
+                "cash".parse().unwrap(),
+                "revenue".parse().unwrap(),
                 1.0,
                 "USD".into(),
                 None,


### PR DESCRIPTION
## Summary
- add `Account` struct for hierarchical names
- support hierarchical accounts when creating records and via CLI
- aggregate balances across subaccounts with `account_tree_balance`
- document hierarchical accounts in architecture docs
- test nested account balances and update existing tests

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_685dea9b04dc832ab5a2e8bec1541565