### PR TITLE
Implement transaction reconciliation

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -70,6 +70,9 @@ pub struct Record {
     pub external_reference: Option<String>,
     /// Tags for categorizing the transaction.
     pub tags: Vec<String>,
+    /// Whether the record has been reconciled with a statement line.
+    #[serde(default)]
+    pub cleared: bool,
 }
 
 impl Record {
@@ -106,6 +109,7 @@ impl Record {
             reference_id,
             external_reference,
             tags,
+            cleared: false,
         })
     }
 
@@ -134,6 +138,15 @@ impl Record {
                 .unwrap_or_default(),
             self.external_reference.clone().unwrap_or_default(),
             self.tags.join(","),
+        ]
+    }
+
+    /// Converts the cleared status into a row for spreadsheet storage.
+    pub fn status_row(&self) -> Vec<String> {
+        vec![
+            "status".to_string(),
+            self.id.to_string(),
+            self.cleared.to_string(),
         ]
     }
 }

--- a/tests/reconcile_tests.rs
+++ b/tests/reconcile_tests.rs
@@ -1,0 +1,31 @@
+use rusty_ledger::cloud_adapters::GoogleSheetsAdapter;
+use rusty_ledger::core::{Permission, Record, SharedLedger};
+
+#[test]
+fn cleared_status_persists() {
+    let adapter = GoogleSheetsAdapter::new();
+    let ledger = SharedLedger::new(adapter, "owner@example.com").unwrap();
+    ledger
+        .share_with("writer@example.com", Permission::Write)
+        .unwrap();
+
+    let record = Record::new(
+        "desc".into(),
+        "cash".parse().unwrap(),
+        "revenue".parse().unwrap(),
+        1.0,
+        "USD".into(),
+        None,
+        None,
+        vec![],
+    )
+    .unwrap();
+    let id = record.id;
+    ledger.commit("writer@example.com", record).unwrap();
+    ledger.mark_cleared("writer@example.com", id).unwrap();
+
+    let (adapter, sheet) = ledger.into_parts();
+    let ledger2 = SharedLedger::from_sheet(adapter, &sheet, "owner@example.com").unwrap();
+    let rec = ledger2.get_record("owner@example.com", id).unwrap();
+    assert!(rec.cleared);
+}


### PR DESCRIPTION
## Summary
- track reconciliation status in `Record`
- store cleared flags using status rows in shared ledger
- add `reconcile` CLI command for statement matching
- expose method to extract adapter for testing
- test that clearing persists in spreadsheet storage

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_685df0a46b38832aae6b2d62a1050eb1