### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,7 +1350,7 @@ checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "rusty-ledger"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-ledger"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Rust-based library that enables applications to interact with cloud-based spread
 Add the following to your Cargo.toml:
 ```toml
 [dependencies]
-rusty-ledger = "1.0.0"
+rusty-ledger = "2.0.0"
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary
- update crate version for 2.0.0 release

## Testing
- `cargo clippy`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_6861cc5b2fac832aa2b080d358de1c88