### PR TITLE
Add split transaction support

### DIFF
--- a/docs/data_model.md
+++ b/docs/data_model.md
@@ -5,8 +5,9 @@ A ledger entry is represented by the `Record` struct. Important fields include:
 - `id` – Unique identifier generated for each record.
 - `timestamp` – Time of creation in UTC.
 - `description` – Human readable explanation of the transaction.
-- `debit_account` and `credit_account` – The accounts affected by the entry.
+- `debit_account` and `credit_account` – The primary accounts affected by the entry.
 - `amount` and `currency` – Monetary value stored as a positive number.
+- `splits` – Optional additional postings for split transactions.
 - `reference_id` – Optional link to another record when posting an adjustment.
 - `external_reference` – Optional external identifier such as an invoice number.
 - `tags` – Free form strings used for categorisation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,6 +82,17 @@ $ cargo run --bin ledger -- add \
 $ cargo run --bin ledger -- list
 ```
 
+Split transactions use the same command with an additional `--splits` argument
+containing a JSON array of extra postings:
+
+```bash
+$ cargo run --bin ledger -- add \
+    --description "Shopping" \
+    --debit expenses:grocery --credit cash \
+    --amount 30 --currency USD \
+    --splits '[{"debit":"expenses:supplies","credit":"cash","amount":20}]'
+```
+
 Before issuing API commands for the first time, authorize the application:
 
 ```bash

--- a/src/core/budget.rs
+++ b/src/core/budget.rs
@@ -91,19 +91,21 @@ fn account_sum(
         if date < start || date > end {
             return acc;
         }
-        let mut amount = r.amount;
-        if r.currency != target {
-            if let Some(rate) = prices.get_rate(date, &r.currency, target) {
-                amount *= rate;
-            } else {
-                return acc;
+        for p in r.postings() {
+            let mut amount = p.amount;
+            if r.currency != target {
+                if let Some(rate) = prices.get_rate(date, &r.currency, target) {
+                    amount *= rate;
+                } else {
+                    continue;
+                }
             }
-        }
-        if r.debit_account.starts_with(account) {
-            acc += amount;
-        }
-        if r.credit_account.starts_with(account) {
-            acc -= amount;
+            if p.debit_account.starts_with(account) {
+                acc += amount;
+            }
+            if p.credit_account.starts_with(account) {
+                acc -= amount;
+            }
         }
         acc
     })

--- a/src/core/query.rs
+++ b/src/core/query.rs
@@ -80,7 +80,9 @@ impl Query {
         }
         if !self.accounts.is_empty()
             && !self.accounts.iter().any(|a| {
-                a == &rec.debit_account.to_string() || a == &rec.credit_account.to_string()
+                rec.postings().any(|p| {
+                    a == &p.debit_account.to_string() || a == &p.credit_account.to_string()
+                })
             })
         {
             return false;

--- a/src/core/sharing.rs
+++ b/src/core/sharing.rs
@@ -140,6 +140,12 @@ impl<S: CloudSpreadsheetService> SharedLedger<S> {
         } else {
             row[9].split(',').map(|s| s.to_string()).collect()
         };
+        let splits = if row.len() >= 11 && !row[10].is_empty() {
+            serde_json::from_str(&row[10])
+                .map_err(|e| SpreadsheetError::Permanent(e.to_string()))?
+        } else {
+            Vec::new()
+        };
 
         Ok(Record {
             id,
@@ -157,6 +163,7 @@ impl<S: CloudSpreadsheetService> SharedLedger<S> {
             external_reference,
             tags,
             cleared: false,
+            splits,
         })
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,6 +309,11 @@ fn record_from_row(row: &[String]) -> Option<Record> {
             row[9].split(',').map(|s| s.to_string()).collect()
         },
         cleared: false,
+        splits: if row.len() >= 11 && !row[10].is_empty() {
+            serde_json::from_str(&row[10]).ok()?
+        } else {
+            Vec::new()
+        },
     })
 }
 


### PR DESCRIPTION
## Summary
- introduce `Posting` struct for split ledger entries
- allow `Record` to store extra postings and create records from multiple postings
- track all postings when calculating balances and queries
- parse and serialize split data in spreadsheets and CLI
- document the new `splits` field in the data model
- test split transaction balance calculations

## Testing
- `cargo fmt`
- `cargo clippy -q`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_b_6862f3b1ac14832aa98abb4cf584004b