### PR TITLE
Add CLI export command

### DIFF
--- a/src/import/csv.rs
+++ b/src/import/csv.rs
@@ -104,3 +104,37 @@ pub fn parse(path: &Path) -> Result<Vec<Record>, ImportError> {
 pub fn parse_with_mapping(path: &Path, mapping: &CsvMapping) -> Result<Vec<Record>, ImportError> {
     CsvImporter::parse_with_mapping(path, mapping)
 }
+
+/// Writes the provided records to a CSV file using the given column mapping.
+pub fn export_with_mapping(
+    path: &Path,
+    records: &[Record],
+    mapping: &CsvMapping,
+) -> Result<(), ImportError> {
+    let mut wtr = csv::Writer::from_path(path).map_err(|e| ImportError::Parse(e.to_string()))?;
+    wtr.write_record([
+        mapping.description.as_str(),
+        mapping.debit_account.as_str(),
+        mapping.credit_account.as_str(),
+        mapping.amount.as_str(),
+        mapping.currency.as_str(),
+    ])
+    .map_err(|e| ImportError::Parse(e.to_string()))?;
+    for rec in records {
+        wtr.write_record([
+            rec.description.as_str(),
+            rec.debit_account.to_string().as_str(),
+            rec.credit_account.to_string().as_str(),
+            rec.amount.to_string().as_str(),
+            rec.currency.as_str(),
+        ])
+        .map_err(|e| ImportError::Parse(e.to_string()))?;
+    }
+    wtr.flush().map_err(|e| ImportError::Parse(e.to_string()))?;
+    Ok(())
+}
+
+/// Convenience wrapper around [`export_with_mapping`].
+pub fn export(path: &Path, records: &[Record]) -> Result<(), ImportError> {
+    export_with_mapping(path, records, &CsvMapping::default())
+}

--- a/tests/import_tests.rs
+++ b/tests/import_tests.rs
@@ -93,3 +93,18 @@ fn ledger_and_json_roundtrip() {
     let _ = std::fs::remove_file(lpath);
     let _ = std::fs::remove_file(jpath);
 }
+
+#[test]
+fn csv_export_roundtrip() {
+    let ledger_text = "2024-01-01 Coffee\n    expenses:food  5.00 USD\n    cash\n";
+    let lpath = write_temp("roundtrip.ledger", ledger_text);
+    let records = ledger::parse(&lpath).unwrap();
+    let cpath = write_temp("roundtrip.csv", "");
+    csv::export(&cpath, &records).unwrap();
+    let loaded = csv::parse(&cpath).unwrap();
+    assert_eq!(loaded.len(), 1);
+    assert_eq!(loaded[0].description, "Coffee");
+    assert_eq!(loaded[0].amount, 5.0);
+    let _ = std::fs::remove_file(lpath);
+    let _ = std::fs::remove_file(cpath);
+}


### PR DESCRIPTION
## Summary
- implement CSV export helper functions
- add `export` command to CLI to write ledger rows in CSV, JSON, or Ledger format
- test CSV export roundtrip

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_6862f94d3878832a975c7e4f27fe7351