### PR TITLE
Add file adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Rust-based library that enables applications to interact with cloud-based spread
 - Immutable Data Entries: Once data is committed, it becomes read-only.
 - Append-Only Adjustments: Modifications are handled by appending new records that reference the original entries.
 - Cloud Service Integration: Supports integration with services like Google Sheets and Microsoft Excel 365.
+- Local File Storage: Save ledger data to CSV files using the `FileAdapter`.
 - User Authentication: Users authenticate via OAuth2 to link their cloud accounts.
 - Data Sharing: Users can share their data with others, controlling access permissions.
 - Resilient API Calls: Automatically retries transient errors with exponential backoff.
@@ -89,6 +90,17 @@ $ cargo run --bin ledger -- add \
 $ cargo run --bin ledger -- list
 ```
 
+Pass `--local-dir <DIR>` to store rows in local CSV files instead of a cloud
+service:
+
+```bash
+$ cargo run --bin ledger -- --local-dir ledger_data add \
+    --description "Coffee" \
+    --debit cash --credit expenses \
+    --amount 3.5 --currency USD
+$ cargo run --bin ledger -- --local-dir ledger_data list
+```
+
 Before issuing API commands for the first time, authorize the application:
 
 ```bash
@@ -141,7 +153,8 @@ $ cargo run --bin ledger -- download --url "https://bank.example.com/statement.o
 # 🛠️ Configuration
 Rusty Ledger looks for a `config.toml` file in the same directory as the
 binary. This file stores your OAuth credentials and the spreadsheet ID used by
-the CLI.
+the CLI. When using `--local-dir`, only the sheet ID is persisted and no OAuth
+credentials are required.
 
 1. Create the file in your project root:
    ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@ title: Overview
 - Immutable Data Entries: Once data is committed, it becomes read-only.
 - Append-Only Adjustments: Modifications are handled by appending new records that reference the original entries.
 - Cloud Service Integration: Supports integration with services like Google Sheets and Microsoft Excel 365.
+- Local File Storage: Save ledger data to CSV files using the `FileAdapter`.
 - User Authentication: Users authenticate via OAuth2 to link their cloud accounts.
 - Data Sharing: Users can share their data with others, controlling access permissions.
 - Resilient API Calls: Automatically retries transient errors with exponential backoff.
@@ -85,6 +86,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+If you prefer to avoid cloud services entirely, `FileAdapter` stores rows in local CSV files:
+
+```rust,no_run
+use rusty_ledger::cloud_adapters::FileAdapter;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut service = FileAdapter::new("./ledger_data");
+    let sheet_id = service.create_sheet("ledger")?;
+    service.append_row(&sheet_id, vec!["hello".into()])?;
+    Ok(())
+}
+```
+
 #### Command Line Interface
 
 The crate ships with a small CLI for local experimentation. To add a record and
@@ -96,6 +110,16 @@ $ cargo run --bin ledger -- add \
     --debit cash --credit expenses \
     --amount 3.5 --currency USD
 $ cargo run --bin ledger -- list
+```
+
+Add `--local-dir <DIR>` to store data in local CSV files:
+
+```bash
+$ cargo run --bin ledger -- --local-dir ledger_data add \
+    --description "Coffee" \
+    --debit cash --credit expenses \
+    --amount 3.5 --currency USD
+$ cargo run --bin ledger -- --local-dir ledger_data list
 ```
 
 Split transactions use the same command with an additional `--splits` argument
@@ -161,7 +185,8 @@ $ cargo run --bin ledger -- download --url "https://bank.example.com/statement.o
 ## 🛠️ Configuration
 Rusty Ledger looks for a `config.toml` file in the same directory as the
 binary. This file stores your OAuth credentials and the spreadsheet ID used by
-the CLI.
+the CLI. When running with `--local-dir`, only the sheet ID is saved and no
+OAuth configuration is needed.
 
 1. Create the file in your project root:
    ```bash

--- a/src/cloud_adapters/file.rs
+++ b/src/cloud_adapters/file.rs
@@ -1,0 +1,107 @@
+use crate::cloud_adapters::{CloudSpreadsheetService, SpreadsheetError};
+use csv::{ReaderBuilder, WriterBuilder};
+use std::path::PathBuf;
+
+/// Adapter that stores spreadsheet data in local CSV files.
+pub struct FileAdapter {
+    base_dir: PathBuf,
+    next_id: usize,
+}
+
+impl FileAdapter {
+    /// Create a new adapter rooted at `base_dir`.
+    pub fn new(base_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            base_dir: base_dir.into(),
+            next_id: 1,
+        }
+    }
+
+    fn sheet_path(&self, id: &str) -> PathBuf {
+        self.base_dir.join(format!("{id}.csv"))
+    }
+}
+
+impl Default for FileAdapter {
+    fn default() -> Self {
+        Self::new(std::env::temp_dir())
+    }
+}
+
+impl CloudSpreadsheetService for FileAdapter {
+    fn create_sheet(&mut self, _title: &str) -> Result<String, SpreadsheetError> {
+        let id = format!("sheet{}", self.next_id);
+        self.next_id += 1;
+        let path = self.sheet_path(&id);
+        std::fs::File::create(&path).map_err(|e| SpreadsheetError::Permanent(e.to_string()))?;
+        Ok(id)
+    }
+
+    fn append_row(&mut self, sheet_id: &str, values: Vec<String>) -> Result<(), SpreadsheetError> {
+        self.append_rows(sheet_id, vec![values])
+    }
+
+    fn append_rows(
+        &mut self,
+        sheet_id: &str,
+        rows: Vec<Vec<String>>,
+    ) -> Result<(), SpreadsheetError> {
+        let path = self.sheet_path(sheet_id);
+        if !path.exists() {
+            return Err(SpreadsheetError::SheetNotFound);
+        }
+        let file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .map_err(|e| SpreadsheetError::Transient(e.to_string()))?;
+        let mut wtr = WriterBuilder::new().has_headers(false).from_writer(file);
+        for row in rows {
+            wtr.write_record(row)
+                .map_err(|e| SpreadsheetError::Transient(e.to_string()))?;
+        }
+        wtr.flush()
+            .map_err(|e| SpreadsheetError::Transient(e.to_string()))
+    }
+
+    fn read_row(&self, sheet_id: &str, index: usize) -> Result<Vec<String>, SpreadsheetError> {
+        let path = self.sheet_path(sheet_id);
+        if !path.exists() {
+            return Err(SpreadsheetError::SheetNotFound);
+        }
+        let file =
+            std::fs::File::open(&path).map_err(|e| SpreadsheetError::Transient(e.to_string()))?;
+        let mut rdr = ReaderBuilder::new().has_headers(false).from_reader(file);
+        for (i, record) in rdr.records().enumerate() {
+            let rec = record.map_err(|e| SpreadsheetError::Transient(e.to_string()))?;
+            if i == index {
+                return Ok(rec.iter().map(|s| s.to_string()).collect());
+            }
+        }
+        Err(SpreadsheetError::RowNotFound)
+    }
+
+    fn list_rows(&self, sheet_id: &str) -> Result<Vec<Vec<String>>, SpreadsheetError> {
+        let path = self.sheet_path(sheet_id);
+        if !path.exists() {
+            return Err(SpreadsheetError::SheetNotFound);
+        }
+        let file =
+            std::fs::File::open(&path).map_err(|e| SpreadsheetError::Transient(e.to_string()))?;
+        let mut rdr = ReaderBuilder::new().has_headers(false).from_reader(file);
+        let mut rows = Vec::new();
+        for record in rdr.records() {
+            let rec = record.map_err(|e| SpreadsheetError::Transient(e.to_string()))?;
+            rows.push(rec.iter().map(|s| s.to_string()).collect());
+        }
+        Ok(rows)
+    }
+
+    fn share_sheet(&self, sheet_id: &str, _email: &str) -> Result<(), SpreadsheetError> {
+        let path = self.sheet_path(sheet_id);
+        if path.exists() {
+            Ok(())
+        } else {
+            Err(SpreadsheetError::ShareFailed)
+        }
+    }
+}

--- a/src/cloud_adapters/mod.rs
+++ b/src/cloud_adapters/mod.rs
@@ -9,6 +9,8 @@ pub mod google_sheets4;
 pub use google_sheets4::GoogleSheets4Adapter;
 pub mod excel_365;
 pub use excel_365::Excel365Adapter;
+pub mod file;
+pub use file::FileAdapter;
 
 use std::collections::HashMap;
 


### PR DESCRIPTION
## Summary
- create a `FileAdapter` for local CSV storage
- expose the adapter in the cloud adapters module
- document the new adapter and update feature lists
- test `FileAdapter` behavior
- allow the CLI to use local CSV storage with `--local-dir`
- document CLI usage of the local adapter

## Testing
- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_686306607b38832a82392bbb5b32a08b