### PR TITLE
Add default workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions: read-all
+
 # Make sure CI fails on all warnings, including Clippy lints
 env:
   RUSTFLAGS: "-Dwarnings"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - 'v*.*.*'
       - 'v*.*.*-*'
+
+permissions: read-all
 jobs:
   build:
     name: Build Binaries
@@ -85,6 +87,8 @@ jobs:
     name: Publish Release
     needs: [build, crate]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- follow GitHub guidance to set default permissions to read-all
- allow `contents: write` for publishing releases

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_b_68635a291108832ab9d2a1cc882f2c47