### PR TITLE
Add support for storing statement descriptions

### DIFF
--- a/docs/data_model.md
+++ b/docs/data_model.md
@@ -11,6 +11,7 @@ A ledger entry is represented by the `Record` struct. Important fields include:
 - `reference_id` – Optional link to another record when posting an adjustment.
 - `external_reference` – Optional external identifier such as an invoice number.
 - `tags` – Free form strings used for categorisation.
+- `transaction_description` – Original description from an imported statement line.
 
 Records are immutable after being committed to the ledger. Adjustments are stored as new records referencing the original entry.
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -87,6 +87,9 @@ pub struct Record {
     pub external_reference: Option<String>,
     /// Tags for categorizing the transaction.
     pub tags: Vec<String>,
+    /// Description from the original statement line, if available.
+    #[serde(default)]
+    pub transaction_description: Option<String>,
     /// Whether the record has been reconciled with a statement line.
     #[serde(default)]
     pub cleared: bool,
@@ -156,6 +159,7 @@ impl Record {
             reference_id,
             external_reference,
             tags,
+            transaction_description: None,
             cleared: false,
             splits: iter.collect(),
         })
@@ -202,6 +206,7 @@ impl Record {
             self.external_reference.clone().unwrap_or_default(),
             self.tags.join(","),
             splits,
+            self.transaction_description.clone().unwrap_or_default(),
         ]
     }
 

--- a/src/core/sharing.rs
+++ b/src/core/sharing.rs
@@ -141,6 +141,7 @@ impl<S: CloudSpreadsheetService> SharedLedger<S> {
             row[9].split(',').map(|s| s.to_string()).collect()
         };
         let splits_col = if row.len() > 10 { &row[10] } else { "" };
+        let tx_desc = if row.len() > 11 { &row[11] } else { "" };
         let splits = if !splits_col.is_empty() {
             serde_json::from_str(splits_col)
                 .map_err(|e| SpreadsheetError::Permanent(e.to_string()))?
@@ -163,6 +164,11 @@ impl<S: CloudSpreadsheetService> SharedLedger<S> {
             reference_id,
             external_reference,
             tags,
+            transaction_description: if tx_desc.is_empty() {
+                None
+            } else {
+                Some(tx_desc.to_string())
+            },
             cleared: false,
             splits,
         })

--- a/src/import/csv.rs
+++ b/src/import/csv.rs
@@ -66,7 +66,7 @@ impl CsvImporter {
                 .unwrap_or_default()
                 .parse()
                 .map_err(|_| ImportError::Parse("invalid account".into()))?;
-            let rec = Record::new(
+            let mut rec = Record::new(
                 row.get(desc_idx).unwrap_or_default().to_string(),
                 debit_acc,
                 credit_acc,
@@ -76,6 +76,7 @@ impl CsvImporter {
                 None,
                 vec![],
             )?;
+            rec.transaction_description = Some(rec.description.clone());
             records.push(rec);
         }
         Ok(records)

--- a/src/import/json.rs
+++ b/src/import/json.rs
@@ -12,7 +12,14 @@ impl JsonImporter {
     }
 
     pub fn parse_str(input: &str) -> Result<Vec<Record>, ImportError> {
-        serde_json::from_str(input).map_err(|e| ImportError::Parse(e.to_string()))
+        let mut records: Vec<Record> =
+            serde_json::from_str(input).map_err(|e| ImportError::Parse(e.to_string()))?;
+        for rec in &mut records {
+            if rec.transaction_description.is_none() {
+                rec.transaction_description = Some(rec.description.clone());
+            }
+        }
+        Ok(records)
     }
 
     fn write(path: &Path, records: &[Record]) -> Result<(), ImportError> {

--- a/src/import/ledger.rs
+++ b/src/import/ledger.rs
@@ -45,7 +45,7 @@ impl LedgerImporter {
                 .trim()
                 .parse()
                 .map_err(|_| ImportError::Parse("invalid account".into()))?;
-            let rec = Record::new(
+            let mut rec = Record::new(
                 description,
                 debit_account,
                 credit_account,
@@ -55,6 +55,7 @@ impl LedgerImporter {
                 None,
                 vec![],
             )?;
+            rec.transaction_description = Some(rec.description.clone());
             records.push(rec);
             while let Some(l) = lines.peek() {
                 if l.trim().is_empty() {

--- a/src/import/ofx.rs
+++ b/src/import/ofx.rs
@@ -34,7 +34,7 @@ impl OfxImporter {
                 } else {
                     ("bank".to_string(), "income".to_string())
                 };
-                let rec = Record::new(
+                let mut rec = Record::new(
                     name.trim().to_string(),
                     debit.parse().unwrap(),
                     credit.parse().unwrap(),
@@ -44,6 +44,7 @@ impl OfxImporter {
                     None,
                     vec![],
                 )?;
+                rec.transaction_description = Some(rec.description.clone());
                 records.push(rec);
             }
         }

--- a/src/import/qif.rs
+++ b/src/import/qif.rs
@@ -43,7 +43,7 @@ impl QifImporter {
                     } else {
                         ("bank".to_string(), "income".to_string())
                     };
-                    let rec = Record::new(
+                    let mut rec = Record::new(
                         desc,
                         debit.parse().unwrap(),
                         credit.parse().unwrap(),
@@ -53,6 +53,7 @@ impl QifImporter {
                         None,
                         vec![],
                     )?;
+                    rec.transaction_description = Some(rec.description.clone());
                     records.push(rec);
                 }
                 amount = None;

--- a/src/main.rs
+++ b/src/main.rs
@@ -323,6 +323,7 @@ fn record_from_row(row: &[String]) -> Option<Record> {
 
     let amount = row[5].parse::<f64>().ok()?;
     let splits_col = if row.len() > 10 { &row[10] } else { "" };
+    let tx_desc = if row.len() > 11 { &row[11] } else { "" };
     Some(Record {
         id: Uuid::nil(),
         timestamp: Utc::now(),
@@ -345,6 +346,11 @@ fn record_from_row(row: &[String]) -> Option<Record> {
             Vec::new()
         } else {
             row[9].split(',').map(|s| s.to_string()).collect()
+        },
+        transaction_description: if tx_desc.is_empty() {
+            None
+        } else {
+            Some(tx_desc.to_string())
         },
         cleared: false,
         splits: if !splits_col.is_empty() {


### PR DESCRIPTION
## Summary
- store original statement description on records
- parse and emit the new description column across importers
- document transaction_description in data model

## Testing
- `cargo clippy --all-features`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68903c39d210832aab5af2e9f6e69831